### PR TITLE
170 indexing camera by port bug if ignore

### DIFF
--- a/pyxy3d/calibration/capture_volume/capture_volume.py
+++ b/pyxy3d/calibration/capture_volume/capture_volume.py
@@ -192,13 +192,17 @@ def xy_reprojection_error(current_param_estimates, capture_volume: CaptureVolume
     # iterate across cameras...while this injects a loop in the residual function
     # it should scale linearly with the number of cameras...a tradeoff for stable
     # and explicit calculations...
+    
     for port, cam in capture_volume.camera_array.cameras.items():
         cam_points = np.where(capture_volume.point_estimates.camera_indices == port)
         object_points = points_3d_and_2d[cam_points][:, 1:4]
 
+        # if a camera is being ignored, it will not show up on the parameter list
+        # so you must use the port index to make sure you read the correct params
+        port_index = capture_volume.camera_array.port_index[port]
         cam_matrix = cam.matrix
-        rvec = camera_params[port][0:3]
-        tvec = camera_params[port][3:6]
+        rvec = camera_params[port_index][0:3]
+        tvec = camera_params[port_index][3:6]
         distortions = cam.distortions
 
         # get the projection of the 2d points on the image plane; ignore the jacobian

--- a/pyxy3d/calibration/capture_volume/helper_functions/get_stereotriangulated_table.py
+++ b/pyxy3d/calibration/capture_volume/helper_functions/get_stereotriangulated_table.py
@@ -34,7 +34,8 @@ def get_stereotriangulated_table(camera_array:CameraArray, point_data_path:Path)
 
 
     xy_camera_indices = point_data["port"].to_numpy()
-    ports = np.unique(xy_camera_indices)
+    # ports = np.unique(xy_camera_indices)
+    ports = [key for key in camera_array.port_index.keys()]
 
     paired_point_builder = StereoPointsBuilder(ports)
 

--- a/pyxy3d/cameras/live_stream.py
+++ b/pyxy3d/cameras/live_stream.py
@@ -61,7 +61,7 @@ class LiveStream:
         if queue not in self.subscribers:
             logger.info(f"Adding queue to subscribers at stream {self.port}")
             self.subscribers.append(queue)
-            logger.info(f"...now {len(self.subscribers)} subscribers at {self.port}")
+            logger.info(f"...now {len(self.subscribers)} subscriber(s) at {self.port}")
         else:
             logger.warn(f"Attempted to subscribe to live stream at port {self.port} twice")
 

--- a/pyxy3d/triangulate/triangulator.py
+++ b/pyxy3d/triangulate/triangulator.py
@@ -29,7 +29,9 @@ class ArrayTriangulator:
     def __init__(self, camera_array: CameraArray):
         self.camera_array = camera_array
         
-        self.ports = list(camera_array.cameras.keys())
+        # pull ports list from camera_array.port_index
+        # to ensure only non-ignored cameras are processed
+        self.ports = list(camera_array.port_index.keys())
         self.pairs = [(i,j) for i,j in combinations(self.ports,2) if i<j]
 
 


### PR DESCRIPTION
Basic testing reveals that things are working....still some finer grain issues to deal with (refreshing the streams after choosing to ignore a camera) but I've put that down as a distinct (and less imperative issue) for now. Moving on to expanding the function of the "Back to Config" button in the GUI... Should basically destroy the stereoframe.

Also, "back" should become disabled when calibration has been initiated