### PR TITLE
346 manage fps by mode in session

### DIFF
--- a/dev/demo/demo_gui_main.py
+++ b/dev/demo/demo_gui_main.py
@@ -7,12 +7,11 @@ from pyxy3d import __app_dir__
 from pyxy3d.gui.main_widget import MainWindow
 
 app_settings = toml.load(Path(__app_dir__, "settings.toml"))
-recent_projects:list = app_settings["recent_projects"]
+recent_projects: list = app_settings["recent_projects"]
 
 recent_project_count = len(recent_projects)
-session_path = Path(recent_projects[recent_project_count-1])
+session_path = Path(recent_projects[recent_project_count - 1])
 
-   
 app = QApplication(sys.argv)
 
 window = MainWindow()

--- a/dev/demo/demo_gui_recording.py
+++ b/dev/demo/demo_gui_recording.py
@@ -33,8 +33,8 @@ session_path = Path(recent_projects[recent_project_count-1])
 config = Configurator(session_path)
 session = Session(config)
 
-session.load_streams()
-session.adjust_resolutions()
+session.load_stream_tools()
+session._adjust_resolutions()
 
 
 App = QApplication(sys.argv)

--- a/dev/demo/demo_gui_recording.py
+++ b/dev/demo/demo_gui_recording.py
@@ -17,7 +17,7 @@ from PyQt6.QtWidgets import (
 import toml
 
 from pyxy3d.gui.recording_widget import RecordingWidget
-from pyxy3d.session.session import Session
+from pyxy3d.session.session import Session, SessionMode
 from pyxy3d.cameras.synchronizer import Synchronizer
 from pyxy3d import __root__
 from pyxy3d.helper import copy_contents
@@ -32,10 +32,7 @@ session_path = Path(recent_projects[recent_project_count-1])
 # copy_contents(session_origin_path,session_path)
 config = Configurator(session_path)
 session = Session(config)
-
-session.load_stream_tools()
-session._adjust_resolutions()
-
+session.set_mode(SessionMode.Recording)
 
 App = QApplication(sys.argv)
 recording_dialog = RecordingWidget(session)

--- a/dev/demo/demo_real_time_triangulator_mediapipe_hands.py
+++ b/dev/demo/demo_real_time_triangulator_mediapipe_hands.py
@@ -35,8 +35,8 @@ session_path = Path(__root__,"dev", "sample_sessions", "low_res")
 session = Session(session_path)
 tracker = TrackerEnum.HAND
 
-session.load_streams(tracker=tracker) 
-session.adjust_resolutions()
+session.load_stream_tools(tracker=tracker) 
+session._adjust_resolutions()
 
 config = Configurator(session_path)
 camera_array = config.get_camera_array()

--- a/pyxy3d/cameras/live_stream.py
+++ b/pyxy3d/cameras/live_stream.py
@@ -104,7 +104,7 @@ class LiveStream(Stream):
         milestones = []
         for i in range(0, fps):
             milestones.append(i / fps)
-        logger.info(f"Setting fps to {self.fps}")
+        logger.info(f"Setting fps to {self.fps} at port {self.port}")
         self.milestones = np.array(milestones)
 
     def update_tracker(self, tracker: Tracker):
@@ -142,10 +142,10 @@ class LiveStream(Stream):
         self.previous_time = self.start_time
         return 1 / self.avg_delta_time
 
-    def stop(self):
-        self.push_to_out_q.clear()
-        self.stop_event.set()
-        logger.info(f"Stop signal sent at stream {self.port}")
+    # def stop(self):
+    #     self.push_to_out_q.clear()
+    #     self.stop_event.set()
+    #     logger.info(f"Stop signal sent at stream {self.port}")
 
     def process_frames(self):
         """

--- a/pyxy3d/cameras/synchronizer.py
+++ b/pyxy3d/cameras/synchronizer.py
@@ -81,7 +81,7 @@ class Synchronizer:
             stream.subscribe(self.frame_packet_queues[port])
         self.subscribed_to_streams = True
 
-    def unsubscribe_to_streams(self):
+    def unsubscribe_from_streams(self):
         for port, stream in self.streams.items():
             logger.info(f"unsubscribe synchronizer from port {port}")
             stream.unsubscribe(self.frame_packet_queues[port])

--- a/pyxy3d/cameras/synchronizer.py
+++ b/pyxy3d/cameras/synchronizer.py
@@ -337,7 +337,7 @@ if __name__ == "__main__":
         # config = Path(session_directory, "config.toml")
         session = Session(session_directory)
         # session.load_cameras()
-        session.load_streams()
+        session.load_stream_tools()
         # session.adjust_resolutions()
 
         for port, stream in session.streams.items():

--- a/pyxy3d/configurator.py
+++ b/pyxy3d/configurator.py
@@ -68,22 +68,27 @@ class Configurator:
         return self.dict["fps_intrinsic_calibration"]  
 
     def save_intrinsic_wait_time(self, time_sec:float):
+        logger.info(f"Updating Intrinsic Calibration Wait to to {time_sec}")
         self.dict["intrinsic_wait_time"] = time_sec
         self.update_toml()             
 
     def save_extrinsic_wait_time(self, time_sec:float):
+        logger.info(f"Updating Extrinsic Calibration Wait to to {time_sec}")
         self.dict["extrinsic_wait_time"] = time_sec
         self.update_toml()
 
     def save_fps_recording(self, fps:int):
+        logger.info(f"Updating Recording fps to {fps}")
         self.dict["fps_recording"]  = fps 
         self.update_toml()
 
     def save_fps_extrinsic_calibration(self, fps:int):
+        logger.info(f"Updating Extrinsic calibration fps to {fps}")
         self.dict["fps_extrinsic_calibration"]  = fps 
         self.update_toml()
 
     def save_fps_intrinsic_calibration(self, fps:int):
+        logger.info(f"Updating Intrinsic calibration fps to {fps}")
         self.dict["fps_intrinsic_calibration"]  = fps 
         self.update_toml()
 

--- a/pyxy3d/configurator.py
+++ b/pyxy3d/configurator.py
@@ -16,9 +16,8 @@ from pyxy3d.calibration.charuco import Charuco
 from pyxy3d.cameras.camera import Camera
 from pyxy3d.cameras.live_stream import LiveStream
 from pyxy3d.interface import Tracker
-from pyxy3d.trackers.tracker_enum import TrackerEnum
 from pyxy3d.cameras.camera_array import CameraArray, CameraData
-from pyxy3d.calibration.capture_volume.point_estimates import PointEstimates, load_point_estimates
+from pyxy3d.calibration.capture_volume.point_estimates import PointEstimates
 from pyxy3d.calibration.capture_volume.capture_volume import CaptureVolume
 from concurrent.futures import ThreadPoolExecutor
 
@@ -42,9 +41,51 @@ class Configurator:
 
             self.dict = toml.loads("")
             self.dict["CreationDate"] = datetime.now()
-            with open(self.toml_path, "a") as f:
-                toml.dump(self.dict, f)
+            self.update_toml()           
+            
+            # default values enforced below 
+            charuco = Charuco(4, 5, 11, 8.5, square_size_overide_cm=5.4)
+            self.save_charuco(charuco)
+            self.save_recording_fps(30)
+            self.save_extrinsic_calibration_fps(6)
+            self.save_extrinsic_wait_time(0.5)
+            self.save_intrinsic_calibration_fps(6)
+            self.save_intrinsic_wait_time(0.5)
+    
+    def get_intrinsic_wait_time(self, time_sec:float):
+        return self.dict["intrinsic_wait_time"] 
+             
+    def get_extrinsic_wait_time(self, time_sec:float):
+        return self.dict["extrinsic_wait_time"] 
 
+    def get_recording_fps(self, fps:int):
+        return self.dict["recording_fps"]  
+
+    def get_extrinsic_calibration_fps(self, fps:int):
+        return self.dict["extrinsic_calibration_fps"]  
+
+    def get_intrinsic_calibration_fps(self, fps:int):
+        return self.dict["intrinsic_calibration_fps"]  
+
+    def save_intrinsic_wait_time(self, time_sec:float):
+        self.dict["intrinsic_wait_time"] = time_sec
+        self.update_toml()             
+
+    def save_extrinsic_wait_time(self, time_sec:float):
+        self.dict["extrinsic_wait_time"] = time_sec
+        self.update_toml()
+
+    def save_recording_fps(self, fps:int):
+        self.dict["recording_fps"]  = fps 
+        self.update_toml()
+
+    def save_extrinsic_calibration_fps(self, fps:int):
+        self.dict["extrinsic_calibration_fps"]  = fps 
+        self.update_toml()
+
+    def save_intrinsic_calibration_fps(self, fps:int):
+        self.dict["intrinsic_calibration_fps"]  = fps 
+        self.update_toml()
 
     def update_toml(self):
         # alphabetize by key to maintain standardized layout
@@ -143,26 +184,27 @@ class Configurator:
         point_estimates = PointEstimates(**point_estimates_dict)
         return point_estimates
     
-    def get_charuco(self):
-        if "charuco" in self.dict:
-            logger.info("Loading charuco from config")
-            params = self.dict["charuco"]
+    def get_charuco(self)-> Charuco:
+        # should now be the case that charuco is *definitely* in there
+        # if "charuco" in self.dict:
+        logger.info("Loading charuco from config")
+        params = self.dict["charuco"]
 
-            charuco = Charuco(
-                columns=params["columns"],
-                rows=params["rows"],
-                board_height=params["board_height"],
-                board_width=params["board_width"],
-                dictionary=params["dictionary"],
-                units=params["units"],
-                aruco_scale=params["aruco_scale"],
-                square_size_overide_cm=params["square_size_overide_cm"],
-                inverted=params["inverted"],
-            )
-        else:
-            logger.info("Loading default charuco")
-            charuco = Charuco(4, 5, 11, 8.5, square_size_overide_cm=5.4)
-            self.save_charuco(charuco)
+        charuco = Charuco(
+            columns=params["columns"],
+            rows=params["rows"],
+            board_height=params["board_height"],
+            board_width=params["board_width"],
+            dictionary=params["dictionary"],
+            units=params["units"],
+            aruco_scale=params["aruco_scale"],
+            square_size_overide_cm=params["square_size_overide_cm"],
+            inverted=params["inverted"],
+        )
+        # else:
+        #     logger.info("Loading default charuco")
+        #     charuco = Charuco(4, 5, 11, 8.5, square_size_overide_cm=5.4)
+        #     self.save_charuco(charuco)
 
         return charuco
 

--- a/pyxy3d/configurator.py
+++ b/pyxy3d/configurator.py
@@ -305,16 +305,16 @@ class Configurator:
         self.update_toml()
 
 
-    def get_live_stream_pool(self, tracker:Tracker = None):
-        streams = {}
-        cameras = self.get_cameras()
+    # def get_live_stream_pool(self, tracker:Tracker = None):
+    #     streams = {}
+    #     cameras = self.get_cameras()
 
-        for port, cam in cameras.items():
-            logger.info(f"Adding stream associated with camera {port}")
-            stream = LiveStream(cam, tracker=tracker)
-            stream.change_resolution(cam.size)
-            streams[port] = stream
-        return streams            
+    #     for port, cam in cameras.items():
+    #         logger.info(f"Adding stream associated with camera {port}")
+    #         stream = LiveStream(cam, tracker=tracker)
+    #         stream.change_resolution(cam.size)
+    #         streams[port] = stream
+    #     return streams            
 
     
      

--- a/pyxy3d/configurator.py
+++ b/pyxy3d/configurator.py
@@ -48,23 +48,23 @@ class Configurator:
             self.save_charuco(charuco)
             self.save_fps_recording(30)
             self.save_fps_extrinsic_calibration(6)
-            self.save_extrinsic_wait_time(0.5)
             self.save_fps_intrinsic_calibration(12)
+            self.save_extrinsic_wait_time(0.5)
             self.save_intrinsic_wait_time(0.5)
     
-    def get_intrinsic_wait_time(self, time_sec:float):
+    def get_intrinsic_wait_time(self):
         return self.dict["intrinsic_wait_time"] 
              
-    def get_extrinsic_wait_time(self, time_sec:float):
+    def get_extrinsic_wait_time(self):
         return self.dict["extrinsic_wait_time"] 
 
-    def get_fps_recording(self, fps:int):
+    def get_fps_recording(self):
         return self.dict["fps_recording"]  
 
-    def get_fps_extrinsic_calibration(self, fps:int):
+    def get_fps_extrinsic_calibration(self):
         return self.dict["fps_extrinsic_calibration"]  
 
-    def get_fps_intrinsic_calibration(self, fps:int):
+    def get_fps_intrinsic_calibration(self):
         return self.dict["fps_intrinsic_calibration"]  
 
     def save_intrinsic_wait_time(self, time_sec:float):

--- a/pyxy3d/configurator.py
+++ b/pyxy3d/configurator.py
@@ -46,10 +46,10 @@ class Configurator:
             # default values enforced below 
             charuco = Charuco(4, 5, 11, 8.5, square_size_overide_cm=5.4)
             self.save_charuco(charuco)
-            self.save_recording_fps(30)
-            self.save_extrinsic_calibration_fps(6)
+            self.save_fps_recording(30)
+            self.save_fps_extrinsic_calibration(6)
             self.save_extrinsic_wait_time(0.5)
-            self.save_intrinsic_calibration_fps(12)
+            self.save_fps_intrinsic_calibration(12)
             self.save_intrinsic_wait_time(0.5)
     
     def get_intrinsic_wait_time(self, time_sec:float):
@@ -59,13 +59,13 @@ class Configurator:
         return self.dict["extrinsic_wait_time"] 
 
     def get_fps_recording(self, fps:int):
-        return self.dict["recording_fps"]  
+        return self.dict["fps_recording"]  
 
     def get_fps_extrinsic_calibration(self, fps:int):
-        return self.dict["extrinsic_calibration_fps"]  
+        return self.dict["fps_extrinsic_calibration"]  
 
     def get_fps_intrinsic_calibration(self, fps:int):
-        return self.dict["intrinsic_calibration_fps"]  
+        return self.dict["fps_intrinsic_calibration"]  
 
     def save_intrinsic_wait_time(self, time_sec:float):
         self.dict["intrinsic_wait_time"] = time_sec
@@ -75,16 +75,16 @@ class Configurator:
         self.dict["extrinsic_wait_time"] = time_sec
         self.update_toml()
 
-    def save_recording_fps(self, fps:int):
-        self.dict["recording_fps"]  = fps 
+    def save_fps_recording(self, fps:int):
+        self.dict["fps_recording"]  = fps 
         self.update_toml()
 
-    def save_extrinsic_calibration_fps(self, fps:int):
-        self.dict["extrinsic_calibration_fps"]  = fps 
+    def save_fps_extrinsic_calibration(self, fps:int):
+        self.dict["fps_extrinsic_calibration"]  = fps 
         self.update_toml()
 
-    def save_intrinsic_calibration_fps(self, fps:int):
-        self.dict["intrinsic_calibration_fps"]  = fps 
+    def save_fps_intrinsic_calibration(self, fps:int):
+        self.dict["fps_intrinsic_calibration"]  = fps 
         self.update_toml()
 
     def update_toml(self):

--- a/pyxy3d/configurator.py
+++ b/pyxy3d/configurator.py
@@ -49,7 +49,7 @@ class Configurator:
             self.save_recording_fps(30)
             self.save_extrinsic_calibration_fps(6)
             self.save_extrinsic_wait_time(0.5)
-            self.save_intrinsic_calibration_fps(6)
+            self.save_intrinsic_calibration_fps(12)
             self.save_intrinsic_wait_time(0.5)
     
     def get_intrinsic_wait_time(self, time_sec:float):

--- a/pyxy3d/configurator.py
+++ b/pyxy3d/configurator.py
@@ -58,13 +58,13 @@ class Configurator:
     def get_extrinsic_wait_time(self, time_sec:float):
         return self.dict["extrinsic_wait_time"] 
 
-    def get_recording_fps(self, fps:int):
+    def get_fps_recording(self, fps:int):
         return self.dict["recording_fps"]  
 
-    def get_extrinsic_calibration_fps(self, fps:int):
+    def get_fps_extrinsic_calibration(self, fps:int):
         return self.dict["extrinsic_calibration_fps"]  
 
-    def get_intrinsic_calibration_fps(self, fps:int):
+    def get_fps_intrinsic_calibration(self, fps:int):
         return self.dict["intrinsic_calibration_fps"]  
 
     def save_intrinsic_wait_time(self, time_sec:float):

--- a/pyxy3d/gui/calibration_widget.py
+++ b/pyxy3d/gui/calibration_widget.py
@@ -69,120 +69,56 @@ class CalibrationWidget(QStackedWidget):
         pass
 
 
-    ######################## STEP 1: Charuco Builder ###########################
 
     def activate_camera_config(self):
-        if hasattr(self, "camera_config"):
-            logger.info("Camera config already exists; changing stack current index")
-            self.session.set_mode(SessionMode.IntrinsicCalibration)
-            active_port = self.camera_config.camera_tabs.currentIndex()
-            self.session.active_monocalibrator = active_port
-            self.setCurrentWidget(self.camera_config)
-            # self.camera_config.camera_tabs.toggle_tracking(active_port)
-
-            # charuco board might have changed, so...
-        else:
-            logger.info("Initiating Camera Connection")
-            self.initiate_camera_connection()
-
-    def initiate_camera_connection(self):
-        if len(self.session.streams) > 0:
-            logger.info("Cameras already connected")
-        else:
-
-            def connect_to_cams_worker():
-                self.CAMS_IN_PROCESS = True
-                logger.info("Initiating camera connect worker")
-
-                # find out if you are loading cameras or finding cameras
-                if self.session.get_configured_camera_count() > 0:
-                    # self.# session.load_cameras()
-                    try:
-                        pass
-
-                    except:
-                        logger.warn("it wasn't safe to comment out this code")
-                        #Mac, if you come back to this well past branch 346 and don't know
-                        # what this is about, just delete it all including the get_configured_count method
-                    
-                    # logger.info("Camera connect worker about to load stream tools")
-
-                    # self.session.load_streams(
-                    #     tracker=CharucoTracker(self.session.charuco)
-                    # )
-                else:
-                    logger.info(
-                        f"No previous configured cameras detected...searching for cameras...."
-                    )
-                    self.session._find_cameras()
-                # logger.info("Camera connect worker about to adjust resolutions")
-                # self.session._adjust_resolutions()
-                # logger.info("Camera connect worker about to load monocalibrators")
-                # self.session._load_monocalibrators()
-                self.session.load_stream_tools()
-                self.CAMS_IN_PROCESS = False
-
-                logger.info("emitting cameras_connected signal")
-                self.cameras_connected.emit()
-                self.camera_config = CameraWizard(self.session)
-                self.addWidget(self.camera_config)
-                self.setCurrentWidget(self.camera_config)
-                self.camera_config.navigation_bar.back_btn.clicked.connect(
-                    self.back_to_charuco_wizard
-                )
-                self.camera_config.navigation_bar.next_btn.clicked.connect(
-                    self.next_to_stereoframe
-                )
-
-                # if hasattr(self, "qt_logger"):
-                #     del self.qt_logger
-                # self.qt_logger.hide()
-
-        if self.CAMS_IN_PROCESS:
-            logger.info("Already attempting to connect to cameras...")
-        else:
-            self.connect_cams = Thread(
-                target=connect_to_cams_worker, args=[], daemon=True
+        self.session.set_mode(SessionMode.IntrinsicCalibration)
+        if not hasattr(self, "camera_wizard"):
+            logger.info(f"No camera configuration yet...creating wizard")
+            self.camera_wizard = CameraWizard(self.session)
+            self.addWidget(self.camera_wizard)
+            self.setCurrentWidget(self.camera_wizard)
+            self.camera_wizard.navigation_bar.back_btn.clicked.connect(
+                self.activate_charuco_wizard
             )
-            self.connect_cams.start()
-
-    # def on_cameras_connect(self):
-        # load cameras config once the cameras are actually connected
+            self.camera_wizard.navigation_bar.next_btn.clicked.connect(
+                self.next_to_stereoframe
+            )
+        else:
+            logger.info("Camera config already exists; changing stack current index")
+            # active_port = self.camera_wizard.camera_tabs.currentIndex()
+            # self.session.active_monocalibrator = active_port
+            self.setCurrentWidget(self.camera_wizard)
+            self.session.activate_monocalibrator()
 
     ####################### STEP 2: Single Camera Calibration #################
-    def back_to_charuco_wizard(self):
+    def activate_charuco_wizard(self):
+        self.session.set_mode(SessionMode.Charuco)
         self.setCurrentWidget(self.wizard_charuco)
-        self.session.pause_all_monocalibrators()
 
     def next_to_stereoframe(self):
-        self.session.pause_all_monocalibrators()
+        self.session.set_mode(SessionMode.ExtrinsicCalibration)
 
-        if hasattr(self.session, "synchronizer"):
-            self.session.unpause_synchronizer()
-
-        self.launch_new_stereoframe()
-
-    def launch_new_stereoframe(self):
         if hasattr(self, "stereoframe"):
-            self.stereoframe.deleteLater()
-            self.removeWidget(self.stereoframe)
-            
-        self.stereoframe = StereoFrameWidget(self.session)
-        self.addWidget(self.stereoframe)
-        self.setCurrentWidget(self.stereoframe)
+            self.setCurrentWidget(self.stereoframe)
+            # self.stereoframe.deleteLater()
+            # self.removeWidget(self.stereoframe)
+        else: 
+            self.stereoframe = StereoFrameWidget(self.session)
+            self.addWidget(self.stereoframe)
+            self.setCurrentWidget(self.stereoframe)
 
-        self.stereoframe.navigation_bar.back_btn.clicked.connect(
-            self.back_to_camera_config_wizard
-        )
+            self.stereoframe.navigation_bar.back_btn.clicked.connect(
+                self.back_to_camera_config_wizard
+            )
 
-        self.stereoframe.calibration_complete.connect(self.next_to_capture_volume)
-        # self.stereoframe.calibration_initiated.connect(self.show_calibration_qt_logger)
-        self.stereoframe.terminate.connect(self.refresh_stereoframe)
+            self.stereoframe.calibration_complete.connect(self.next_to_capture_volume)
+            # self.stereoframe.calibration_initiated.connect(self.show_calibration_qt_logger)
+            self.stereoframe.terminate.connect(self.refresh_stereoframe)
 
     ###################### Stereocalibration  ######################################
     def refresh_stereoframe(self):
         logger.info("Set current widget to config temporarily")
-        self.setCurrentWidget(self.camera_config)
+        self.setCurrentWidget(self.camera_wizard)
 
         logger.info("Remove stereoframe")
         self.removeWidget(self.stereoframe)
@@ -192,26 +128,18 @@ class CalibrationWidget(QStackedWidget):
         logger.info("Create new stereoframe")
         self.launch_new_stereoframe()
 
-    # def show_calibration_qt_logger(self):
-    #     """
-    #     Calibration is initiated back on the stereoframe widget,here only
-    #     the logger launch is managed because it is main that must delete the logger
-    #     """
-    #     logger.info("Launching calibration qt logger")
-    #     self.qt_logger = QtLogger("Calibrating camera array...")
-    #     self.qt_logger.show()
 
     def back_to_camera_config_wizard(self):
         logger.info("Moving back to camera config from stereoframe")
-        self.setCurrentWidget(self.camera_config)
+        self.setCurrentWidget(self.camera_wizard)
         self.session.pause_synchronizer()
 
         self.stereoframe.frame_builder.unsubscribe_from_synchronizer()
         self.removeWidget(self.stereoframe)
         del self.stereoframe
 
-        active_port = self.camera_config.camera_tabs.currentIndex()
-        self.camera_config.camera_tabs.toggle_tracking(active_port)
+        active_port = self.camera_wizard.camera_tabs.currentIndex()
+        self.camera_wizard.camera_tabs.activate_current_tab(active_port)
 
     def next_to_capture_volume(self):
         logger.info("Creating Capture Volume widget")
@@ -229,7 +157,7 @@ class CalibrationWidget(QStackedWidget):
     ################## Capture Volume ########################
     def back_to_stereo_frame(self):
         logger.info("Set current widget to config temporarily")
-        self.setCurrentWidget(self.camera_config)
+        self.setCurrentWidget(self.camera_wizard)
 
         logger.info("Remove stereoframe")
         self.removeWidget(self.stereoframe)

--- a/pyxy3d/gui/calibration_widget.py
+++ b/pyxy3d/gui/calibration_widget.py
@@ -115,10 +115,11 @@ class CalibrationWidget(QStackedWidget):
                         f"No previous configured cameras detected...searching for cameras...."
                     )
                     self.session._find_cameras()
-                logger.info("Camera connect worker about to adjust resolutions")
-                self.session._adjust_resolutions()
-                logger.info("Camera connect worker about to load monocalibrators")
-                self.session._load_monocalibrators()
+                # logger.info("Camera connect worker about to adjust resolutions")
+                # self.session._adjust_resolutions()
+                # logger.info("Camera connect worker about to load monocalibrators")
+                # self.session._load_monocalibrators()
+                self.session.load_stream_tools()
                 self.CAMS_IN_PROCESS = False
 
                 logger.info("emitting cameras_connected signal")

--- a/pyxy3d/gui/calibration_widget.py
+++ b/pyxy3d/gui/calibration_widget.py
@@ -116,11 +116,19 @@ class CalibrationWidget(QStackedWidget):
                 # find out if you are loading cameras or finding cameras
                 if self.session.get_configured_camera_count() > 0:
                     # self.# session.load_cameras()
-                    logger.info("Camera connect worker about to load stream tools")
+                    try:
+                        pass
 
-                    self.session.load_streams(
-                        tracker=CharucoTracker(self.session.charuco)
-                    )
+                    except:
+                        logger.warn("it wasn't safe to comment out this code")
+                        #Mac, if you come back to this well past branch 346 and don't know
+                        # what this is about, just delete it all including the get_configured_count method
+                    
+                    # logger.info("Camera connect worker about to load stream tools")
+
+                    # self.session.load_streams(
+                    #     tracker=CharucoTracker(self.session.charuco)
+                    # )
                 else:
                     logger.info(
                         f"No previous configured cameras detected...searching for cameras...."

--- a/pyxy3d/gui/calibration_widget.py
+++ b/pyxy3d/gui/calibration_widget.py
@@ -114,11 +114,11 @@ class CalibrationWidget(QStackedWidget):
                     logger.info(
                         f"No previous configured cameras detected...searching for cameras...."
                     )
-                    self.session.find_cameras()
+                    self.session._find_cameras()
                 logger.info("Camera connect worker about to adjust resolutions")
-                self.session.adjust_resolutions()
+                self.session._adjust_resolutions()
                 logger.info("Camera connect worker about to load monocalibrators")
-                self.session.load_monocalibrators()
+                self.session._load_monocalibrators()
                 self.CAMS_IN_PROCESS = False
 
                 logger.info("emitting cameras_connected signal")

--- a/pyxy3d/gui/camera_config/camera_config_dialogue.py
+++ b/pyxy3d/gui/camera_config/camera_config_dialogue.py
@@ -491,9 +491,9 @@ if __name__ == "__main__":
 
     tracker = CharucoTracker(session.charuco)
     # # session.load_cameras()
-    session.load_streams(tracker=tracker)
-    session.adjust_resolutions()
-    session.load_monocalibrators()
+    session.load_stream_tools(tracker=tracker)
+    session._adjust_resolutions()
+    session._load_monocalibrators()
     test_port = 0
 
     App = QApplication(sys.argv)

--- a/pyxy3d/gui/camera_config/camera_config_dialogue.py
+++ b/pyxy3d/gui/camera_config/camera_config_dialogue.py
@@ -302,7 +302,8 @@ class AdvancedControls(QWidget):
         self.frame_emitter.FPSBroadcast.connect(FPSUpdateSlot)
         
     def on_wait_time_spin(self, wait_time):
-        self.monocal.wait_time = wait_time
+        self.session.wait_time_intrinsic = wait_time
+        self.session.config.save_intrinsic_wait_time(wait_time)
 
         
     def on_frame_rate_spin(self,fps_rate):

--- a/pyxy3d/gui/camera_config/camera_config_dialogue.py
+++ b/pyxy3d/gui/camera_config/camera_config_dialogue.py
@@ -307,7 +307,7 @@ class AdvancedControls(QWidget):
         
     def on_frame_rate_spin(self,fps_rate):
         # self.stream.set_fps_target(fps_rate)
-        self.monocal.set_stream_fps(fps_rate)
+        self.session.set_active_mode_fps(fps_rate)
         logger.info(f"Changing monocalibrator frame rate for port{self.port}")
 
     def FPSUpdateSlot(self,fps):

--- a/pyxy3d/gui/camera_config/camera_config_dialogue.py
+++ b/pyxy3d/gui/camera_config/camera_config_dialogue.py
@@ -492,8 +492,6 @@ if __name__ == "__main__":
     tracker = CharucoTracker(session.charuco)
     # # session.load_cameras()
     session.load_stream_tools(tracker=tracker)
-    session._adjust_resolutions()
-    session._load_monocalibrators()
     test_port = 0
 
     App = QApplication(sys.argv)

--- a/pyxy3d/gui/camera_config/camera_config_dialogue.py
+++ b/pyxy3d/gui/camera_config/camera_config_dialogue.py
@@ -35,10 +35,10 @@ from pyxy3d.gui.camera_config.camera_summary_widget import SummaryWidget
 from pyxy3d import __root__
 
 
-class CameraConfigDialog(QDialog):
+class CameraConfigTab(QDialog):
     
     def __init__(self, session, port):
-        super(CameraConfigDialog, self).__init__()
+        super(CameraConfigTab, self).__init__()
 
         # set up variables for ease of reference
         self.session = session
@@ -497,7 +497,7 @@ if __name__ == "__main__":
     App = QApplication(sys.argv)
 
     logger.info("Creating Camera Config Dialog")
-    cam_dialog = CameraConfigDialog(session, test_port)
+    cam_dialog = CameraConfigTab(session, test_port)
     cam_dialog.show()
     
     logger.info("About to show camera config dialog")

--- a/pyxy3d/gui/camera_config/camera_summary_widget.py
+++ b/pyxy3d/gui/camera_config/camera_summary_widget.py
@@ -134,7 +134,7 @@ if __name__ == "__main__":
     session_path = Path(recent_projects[recent_project_count - 1])
     config = Configurator(session_path)
     session = Session(config)
-    session.load_streams()
+    session.load_stream_tools()
     
     port = 2
 

--- a/pyxy3d/gui/camera_config/camera_tabs.py
+++ b/pyxy3d/gui/camera_config/camera_tabs.py
@@ -66,7 +66,7 @@ class CameraTabs(QTabWidget):
     def toggle_tracking(self, index):
 
         logger.info(f"Toggle tracking to activate {self.tabText(index)}")
-        self.session.set_active_monocalibrator(self.widget(index).stream.port)
+        self.session.activate_monocalibrator(self.widget(index).stream.port)
 
 
     def add_cam_tabs(self):

--- a/pyxy3d/gui/camera_config/camera_tabs.py
+++ b/pyxy3d/gui/camera_config/camera_tabs.py
@@ -136,8 +136,6 @@ if __name__ == "__main__":
     session = Session(config_path)
     # session.load_cameras()
     session.load_stream_tools()
-    # session.adjust_resolutions()
-    session._load_monocalibrators()
 
     test_port = 0
 

--- a/pyxy3d/gui/camera_config/camera_tabs.py
+++ b/pyxy3d/gui/camera_config/camera_tabs.py
@@ -83,7 +83,7 @@ class CameraTabs(QTabWidget):
         self.widget(index).advanced_controls.frame_rate_spin.setValue(monocal_fps)
 
         wait_time_intrinsic = self.session.wait_time_intrinsic
-        self.widget(index).advanced_controls.frame_rate_spin.setValue(monocal_fps)
+        self.widget(index).advanced_controls.wait_time_spin.setValue(wait_time_intrinsic)
 
     def add_cam_tabs(self):
         tab_names = [self.tabText(i) for i in range(self.count())]

--- a/pyxy3d/gui/camera_config/camera_tabs.py
+++ b/pyxy3d/gui/camera_config/camera_tabs.py
@@ -135,9 +135,9 @@ if __name__ == "__main__":
     print(config_path)
     session = Session(config_path)
     # session.load_cameras()
-    session.load_streams()
+    session.load_stream_tools()
     # session.adjust_resolutions()
-    session.load_monocalibrators()
+    session._load_monocalibrators()
 
     test_port = 0
 

--- a/pyxy3d/gui/camera_config/camera_tabs.py
+++ b/pyxy3d/gui/camera_config/camera_tabs.py
@@ -13,7 +13,7 @@ from PyQt6.QtWidgets import (
     QTabWidget,
 )
 
-from pyxy3d.gui.camera_config.camera_config_dialogue import CameraConfigDialog
+from pyxy3d.gui.camera_config.camera_config_dialogue import CameraConfigTab
 from pyxy3d.session.session import Session, SessionMode
 from pyxy3d.session.get_stage import get_camera_stage, CameraStage
 from pyxy3d.gui.navigation_bars import NavigationBarBackNext
@@ -78,6 +78,8 @@ class CameraTabs(QTabWidget):
         self.session.pause_all_monocalibrators()
         self.session.activate_monocalibrator(self.widget(index).stream.port)
 
+        # this is where you can update the spin boxes to align with the session values
+        self.widget(index).
 
     def add_cam_tabs(self):
         tab_names = [self.tabText(i) for i in range(self.count())]
@@ -93,7 +95,7 @@ class CameraTabs(QTabWidget):
                 if tab_name in tab_names:
                     pass  # already here, don't bother
                 else:
-                    cam_tab = CameraConfigDialog(self.session, port)
+                    cam_tab = CameraConfigTab(self.session, port)
                     
                     # when new camera calibrated, check to see if all cameras calibrated
                     cam_tab.calibrate_grp.calibration_change.connect(self.check_session_calibration)

--- a/pyxy3d/gui/camera_config/camera_tabs.py
+++ b/pyxy3d/gui/camera_config/camera_tabs.py
@@ -53,7 +53,7 @@ class CameraTabs(QTabWidget):
         self.setTabPosition(QTabWidget.TabPosition.North)
         self.add_cam_tabs()
         # self.session.set_mode(SessionMode.IntrinsicCalibration)
-        # self.currentChanged.connect(self.toggle_tracking)
+        self.currentChanged.connect(self.activate_current_tab)
 
     def keyPressEvent(self, event):
         """
@@ -72,10 +72,11 @@ class CameraTabs(QTabWidget):
             super().keyPressEvent(event)
         
         
-    # def toggle_tracking(self, index):
+    def activate_current_tab(self, index):
 
-    #     logger.info(f"Toggle tracking to activate {self.tabText(index)}")
-    #     self.session.activate_monocalibrator(self.widget(index).stream.port)
+        logger.info(f"Toggle tracking to activate {self.tabText(index)}")
+        self.session.pause_all_monocalibrators()
+        self.session.activate_monocalibrator(self.widget(index).stream.port)
 
 
     def add_cam_tabs(self):

--- a/pyxy3d/gui/camera_config/camera_tabs.py
+++ b/pyxy3d/gui/camera_config/camera_tabs.py
@@ -79,7 +79,8 @@ class CameraTabs(QTabWidget):
         self.session.activate_monocalibrator(self.widget(index).stream.port)
 
         # this is where you can update the spin boxes to align with the session values
-        self.widget(index).
+        monocal_fps = self.session.get_active_mode_fps()
+        self.widget(index).advanced_controls.frame_rate_spin.setValue(monocal_fps)
 
     def add_cam_tabs(self):
         tab_names = [self.tabText(i) for i in range(self.count())]

--- a/pyxy3d/gui/camera_config/camera_tabs.py
+++ b/pyxy3d/gui/camera_config/camera_tabs.py
@@ -14,12 +14,15 @@ from PyQt6.QtWidgets import (
 )
 
 from pyxy3d.gui.camera_config.camera_config_dialogue import CameraConfigDialog
-from pyxy3d.session.session import Session
+from pyxy3d.session.session import Session, SessionMode
 from pyxy3d.session.get_stage import get_camera_stage, CameraStage
 from pyxy3d.gui.navigation_bars import NavigationBarBackNext
 
 class CameraWizard(QWidget):
-    def __init__(self, session):
+    """ 
+    This is basically just the camera tabs plus the navigation bar
+    """
+    def __init__(self, session: Session):
         super(CameraWizard, self).__init__()
         self.setLayout(QVBoxLayout())    
         self.camera_tabs = CameraTabs(session)
@@ -29,6 +32,11 @@ class CameraWizard(QWidget):
     
         self.camera_tabs.stereoframe_ready.connect(self.set_next_enabled)
         self.camera_tabs.check_session_calibration()
+        self.session = session
+        
+        #prior to entering intrinisc calibration mode, need to have an active monocalibrator
+        # self.session.active_monocalibrator = self.camera_tabs.currentWidget().port
+        # self.session.set_mode(SessionMode.Charuco)
          
     def set_next_enabled(self, stereoframe_ready:bool):
         logger.info(f"Setting camera tab next button enabled status to {stereoframe_ready}")
@@ -44,7 +52,8 @@ class CameraTabs(QTabWidget):
 
         self.setTabPosition(QTabWidget.TabPosition.North)
         self.add_cam_tabs()
-        self.currentChanged.connect(self.toggle_tracking)
+        # self.session.set_mode(SessionMode.IntrinsicCalibration)
+        # self.currentChanged.connect(self.toggle_tracking)
 
     def keyPressEvent(self, event):
         """
@@ -63,10 +72,10 @@ class CameraTabs(QTabWidget):
             super().keyPressEvent(event)
         
         
-    def toggle_tracking(self, index):
+    # def toggle_tracking(self, index):
 
-        logger.info(f"Toggle tracking to activate {self.tabText(index)}")
-        self.session.activate_monocalibrator(self.widget(index).stream.port)
+    #     logger.info(f"Toggle tracking to activate {self.tabText(index)}")
+    #     self.session.activate_monocalibrator(self.widget(index).stream.port)
 
 
     def add_cam_tabs(self):
@@ -102,7 +111,7 @@ class CameraTabs(QTabWidget):
         else:
             logger.info("No cameras available")
         
-        self.toggle_tracking(self.currentIndex())
+        # self.toggle_tracking(self.currentIndex())
 
     def check_session_calibration(self):
         logger.info(f"Checking session stage....")

--- a/pyxy3d/gui/camera_config/camera_tabs.py
+++ b/pyxy3d/gui/camera_config/camera_tabs.py
@@ -82,6 +82,9 @@ class CameraTabs(QTabWidget):
         monocal_fps = self.session.get_active_mode_fps()
         self.widget(index).advanced_controls.frame_rate_spin.setValue(monocal_fps)
 
+        wait_time_intrinsic = self.session.wait_time_intrinsic
+        self.widget(index).advanced_controls.frame_rate_spin.setValue(monocal_fps)
+
     def add_cam_tabs(self):
         tab_names = [self.tabText(i) for i in range(self.count())]
         logger.info(f"Current tabs are: {tab_names}")

--- a/pyxy3d/gui/main_widget.py
+++ b/pyxy3d/gui/main_widget.py
@@ -104,15 +104,17 @@ class MainWindow(QMainWindow):
         logger.info(f"Switching main window to tab {index}")
         match index:
             case 0:
+                
                 logger.info(f"Activate Calibration Mode")
-                match self.calibration_widget.currentWidget():
-                    case self.calibration_widget.camera_wizard:
-                        active_camera = self.calibration_widget.camera_wizard.camera_tabs.currentWidget().port
-                        logger.info(f"Activating intrinsic calibration tab: camera config widget with Camera {active_camera} active")
-                        self.session.set_mode(SessionMode.IntrinsicCalibration)
-                    case self.calibration_widget.stereoframe:
-                        logger.info("Activating extrinsic calibration tab: stereoframe widget")
-                        self.session.set_mode(SessionMode.ExtrinsicCalibration)
+                if hasattr(self.calibration_widget,"currentWidget"):
+                    match self.calibration_widget.currentWidget():
+                        case self.calibration_widget.camera_wizard:
+                            active_camera = self.calibration_widget.camera_wizard.camera_tabs.currentWidget().port
+                            logger.info(f"Activating intrinsic calibration tab: camera config widget with Camera {active_camera} active")
+                            self.session.set_mode(SessionMode.IntrinsicCalibration)
+                        case self.calibration_widget.stereoframe:
+                            logger.info("Activating extrinsic calibration tab: stereoframe widget")
+                            self.session.set_mode(SessionMode.ExtrinsicCalibration)
 
             case 1:
                 logger.info(f"Activate Recording Mode")

--- a/pyxy3d/gui/main_widget.py
+++ b/pyxy3d/gui/main_widget.py
@@ -126,7 +126,7 @@ class MainWindow(QMainWindow):
             case self.calibration_widget.camera_config:
                 active_camera = self.calibration_widget.camera_config.camera_tabs.currentWidget().port
                 logger.info(f"Activating calibration tab: camera config widget with Camera {active_camera} active")
-                self.session.set_active_monocalibrator(active_camera) # restores fps
+                self.session.activate_monocalibrator(active_camera) # restores fps
             case self.calibration_widget.stereoframe:
                 logger.info("Activating calibration tab: stereoframe widget")
                 self.session.unpause_synchronizer()

--- a/pyxy3d/gui/main_widget.py
+++ b/pyxy3d/gui/main_widget.py
@@ -123,8 +123,8 @@ class MainWindow(QMainWindow):
         self.session.pause_all_monocalibrators()
         
         match self.calibration_widget.currentWidget():
-            case self.calibration_widget.camera_config:
-                active_camera = self.calibration_widget.camera_config.camera_tabs.currentWidget().port
+            case self.calibration_widget.camera_wizard:
+                active_camera = self.calibration_widget.camera_wizard.camera_tabs.currentWidget().port
                 logger.info(f"Activating calibration tab: camera config widget with Camera {active_camera} active")
                 self.session.activate_monocalibrator(active_camera) # restores fps
             case self.calibration_widget.stereoframe:

--- a/pyxy3d/gui/main_widget.py
+++ b/pyxy3d/gui/main_widget.py
@@ -168,7 +168,7 @@ class MainWindow(QMainWindow):
         logger.info(f"Launching session with config file stored in {session_path}")
         self.session = Session(self.config)
         logger.info("Setting calibration Widget")
-        self.session.synchronizer_created.connect(self.load_recording_widget)
+        self.session.stream_tools_loaded_signal.connect(self.load_recording_widget)
 
 
         old_index = self.tab_widget.currentIndex()

--- a/pyxy3d/gui/main_widget.py
+++ b/pyxy3d/gui/main_widget.py
@@ -23,7 +23,7 @@ import toml
 from PyQt6.QtGui import QIcon, QAction, QKeySequence, QShortcut
 from PyQt6.QtCore import Qt
 from pyxy3d import __root__, __settings_path__, __user_dir__
-from pyxy3d.session.session import Session
+from pyxy3d.session.session import Session, SessionMode
 from pyxy3d.gui.log_widget import LogWidget
 from pyxy3d.configurator import Configurator
 from pyxy3d.gui.calibration_widget import CalibrationWidget
@@ -99,57 +99,27 @@ class MainWindow(QMainWindow):
     def connect_signals(self):
         self.tab_widget.currentChanged.connect(self.on_tab_changed)
 ################## FRAME READING and TRACKING CONTROL with TAB SWITCH ######################################        
-    def activate_recording(self):
-        self.session.pause_all_monocalibrators()
-        self.session.synchronizer.set_tracking_on_streams(False)
-        
-        self.session.unpause_synchronizer() # unpause restores fps
-   
-   
-    def activate_processing(self):
-        self.session.pause_all_monocalibrators()
-        self.session.pause_synchronizer()
          
-    def activate_calibration(self):
-
-        if hasattr(self.session, "synchronizer"):
-            self.session.pause_synchronizer()
-            # synched frames not running, but a handy way to turn tracking on all by default
-            self.session.synchronizer.set_tracking_on_streams(True)
-            
-            # set syncronizer fps target to align with stereoframe fps spin box 
-            self.session.synchronizer.fps_target = self.calibration_widget.stereoframe.frame_rate_spin.value()
-
-        self.session.pause_all_monocalibrators()
-        
-        match self.calibration_widget.currentWidget():
-            case self.calibration_widget.camera_wizard:
-                active_camera = self.calibration_widget.camera_wizard.camera_tabs.currentWidget().port
-                logger.info(f"Activating calibration tab: camera config widget with Camera {active_camera} active")
-                self.session.activate_monocalibrator(active_camera) # restores fps
-            case self.calibration_widget.stereoframe:
-                logger.info("Activating calibration tab: stereoframe widget")
-                self.session.unpause_synchronizer()
-                # pass
-                #Mac RETURN HERE     
-                # case self.calibration_widget.stereoframe
-
-    
-    
-
     def on_tab_changed(self, index):
         logger.info(f"Switching main window to tab {index}")
         match index:
             case 0:
-                logger.info(f"Activate Calibration Tab")
-                self.activate_calibration()
+                logger.info(f"Activate Calibration Mode")
+                match self.calibration_widget.currentWidget():
+                    case self.calibration_widget.camera_wizard:
+                        active_camera = self.calibration_widget.camera_wizard.camera_tabs.currentWidget().port
+                        logger.info(f"Activating intrinsic calibration tab: camera config widget with Camera {active_camera} active")
+                        self.session.set_mode(SessionMode.IntrinsicCalibration)
+                    case self.calibration_widget.stereoframe:
+                        logger.info("Activating extrinsic calibration tab: stereoframe widget")
+                        self.session.set_mode(SessionMode.ExtrinsicCalibration)
 
             case 1:
-                logger.info(f"Activate Recording Tab")
-                self.activate_recording()
+                logger.info(f"Activate Recording Mode")
+                self.session.set_mode(SessionMode.Recording)
             case 2:
-                logger.info(f"Activate Processing Tab")
-                self.activate_processing()
+                logger.info(f"Activate Processing Mode")
+                self.session.set_mode(SessionMode.PostProcessing)
             
     
 

--- a/pyxy3d/gui/recording_widget.py
+++ b/pyxy3d/gui/recording_widget.py
@@ -356,8 +356,8 @@ def cv2_to_qlabel(frame):
 def launch_recording_widget(session_path):
             config = Configurator(session_path)
             session = Session(config)
-            session.load_streams()
-            session.adjust_resolutions()
+            session.load_stream_tools()
+            session._adjust_resolutions()
 
             App = QApplication(sys.argv)
             recording_dialog = RecordingWidget(session)

--- a/pyxy3d/gui/recording_widget.py
+++ b/pyxy3d/gui/recording_widget.py
@@ -58,7 +58,7 @@ class RecordingWidget(QWidget):
         self.video_recorder = VideoRecorder(self.synchronizer)
         
         self.frame_rate_spin = QSpinBox()
-        self.frame_rate_spin.setValue(self.synchronizer.fps_target)
+        self.frame_rate_spin.setValue(self.session.fps_recording)
 
         self.start_stop = QPushButton("Start Recording")
         self.destination_label = QLabel("Recording Destination:")
@@ -111,7 +111,7 @@ class RecordingWidget(QWidget):
     def connect_widgets(self):
     
         self.frame_emitter.ImageBroadcast.connect(self.ImageUpdateSlot)
-        self.frame_rate_spin.valueChanged.connect(self.synchronizer.set_stream_fps)
+        self.frame_rate_spin.valueChanged.connect(self.session.set_active_mode_fps)
         self.frame_emitter.dropped_fps.connect(self.update_dropped_fps)
         self.start_stop.clicked.connect(self.toggle_start_stop)
 

--- a/pyxy3d/gui/stereoframe/stereo_frame_builder.py
+++ b/pyxy3d/gui/stereoframe/stereo_frame_builder.py
@@ -380,7 +380,7 @@ if __name__ == "__main__":
         session_directory = Path(__root__, "tests", "4_cameras_beginning")
         session = Session(session_directory)
         # session.load_cameras()
-        session.load_streams()
+        session.load_stream_tools()
         logger.info("Creating Synchronizer")
         syncr = Synchronizer(session.streams, fps_target=3)
     else:

--- a/pyxy3d/gui/stereoframe/stereo_frame_builder.py
+++ b/pyxy3d/gui/stereoframe/stereo_frame_builder.py
@@ -426,7 +426,7 @@ if __name__ == "__main__":
             frame_builder.reset()
 
         if key == ord("u"):
-            frame_builder.synchronizer.unsubscribe_to_streams() 
+            frame_builder.synchronizer.unsubscribe_from_streams() 
             
         if frame_builder.possible_to_initialize_array(5):
             logger.info("possible to initialize array now")

--- a/pyxy3d/gui/stereoframe/stereo_frame_widget.py
+++ b/pyxy3d/gui/stereoframe/stereo_frame_widget.py
@@ -247,7 +247,6 @@ if __name__ == "__main__":
         # session.load_cameras()
         tracker = CharucoTracker(session.charuco)
         session.load_stream_tools(tracker=tracker)
-        session._adjust_resolutions()
 
 
         stereo_dialog = StereoFrameWidget(session)

--- a/pyxy3d/gui/stereoframe/stereo_frame_widget.py
+++ b/pyxy3d/gui/stereoframe/stereo_frame_widget.py
@@ -246,8 +246,8 @@ if __name__ == "__main__":
         session = Session(configurator)
         # session.load_cameras()
         tracker = CharucoTracker(session.charuco)
-        session.load_streams(tracker=tracker)
-        session.adjust_resolutions()
+        session.load_stream_tools(tracker=tracker)
+        session._adjust_resolutions()
 
 
         stereo_dialog = StereoFrameWidget(session)

--- a/pyxy3d/interface.py
+++ b/pyxy3d/interface.py
@@ -93,7 +93,11 @@ class Stream(ABC):
     @abstractmethod
     def set_tracking_on(self, track: bool):
         pass
-
+    
+    @abstractmethod
+    def set_fps_target(self, fps_target:int):
+        pass
+    
     @abstractmethod
     def process_frames(self):
         pass

--- a/pyxy3d/logger.py
+++ b/pyxy3d/logger.py
@@ -83,11 +83,14 @@ def get(name): # as in __name__
     else:
         logger.setLevel(logging.INFO) 
 
-    qt_handler = QtHandler()
     
     logger.addHandler(app_dir_file_handler)
     logger.addHandler(console_handler)
-    logger.addHandler(qt_handler)
+   
+    # avoid stepping through XStream object if in debug 
+    if os.getenv("DEBUG") != '1':
+        qt_handler = QtHandler()
+        logger.addHandler(qt_handler)
     
 
     return logger

--- a/pyxy3d/session/session.py
+++ b/pyxy3d/session/session.py
@@ -93,20 +93,19 @@ class Session(QObject):
 
         match self.mode:
             case SessionMode.Charuco:
-                if hasattr(self,"synchronizer"):
+                if self.stream_tools_loaded:
                     self.synchronizer.unsubscribe_from_streams()
                     self.pause_all_monocalibrators()
+
             case SessionMode.PostProcessing:
-                
-                if hasattr(self,"synchronizer"):
+                                
+                if self.stream_tools_loaded:
                     self.synchronizer.unsubscribe_from_streams()
                     self.pause_all_monocalibrators()
 
             case SessionMode.IntrinsicCalibration:
-                if not hasattr(self, "synchronizer"):
+                if not self.stream_tools_loaded:
                     self.load_stream_tools()
-                if len(self.monocalibrators) == 0:
-                    self._load_monocalibrators()
                 self.synchronizer.unsubscribe_from_streams()
                 self.pause_all_monocalibrators()
                 self.set_streams_charuco()
@@ -114,20 +113,16 @@ class Session(QObject):
                 self.activate_monocalibrator(self.active_monocalibrator)
 
             case SessionMode.ExtrinsicCalibration:
-                if not hasattr(self, "synchronizer"):
+                if not self.stream_tools_loaded:
                     self.load_stream_tools()
-                if len(self.monocalibrators) == 0:
-                    self._load_monocalibrators()
 
                 self.pause_all_monocalibrators()
                 self.set_streams_charuco()
                 self.set_streams_tracking(True)
                 self.synchronizer.subscribe_to_streams()
             case SessionMode.Recording:
-                if not hasattr(self, "synchronizer"):
+                if not self.stream_tools_loaded:
                     self.load_stream_tools()
-                if len(self.monocalibrators) == 0:
-                    self._load_monocalibrators()
 
                 self.pause_all_monocalibrators()
                 self.set_streams_tracking(False)

--- a/pyxy3d/session/session.py
+++ b/pyxy3d/session/session.py
@@ -67,6 +67,7 @@ class Session(QObject):
 
         # dictionaries of calibration related objects.
         self.monocalibrators = {}  # key = port
+        self.active_monocalibrator = None
 
         # load fps for various modes
         self.recording_fps = self.config.get_recording_fps()
@@ -78,10 +79,19 @@ class Session(QObject):
 
         self.charuco = self.config.get_charuco()
         self.charuco_tracker = CharucoTracker(self.charuco)
+        self.mode = SessionMode.Charuco # default mode of session
+         
+    def set_fps(self):
+        match self.mode:
+            case SessionMode.Charuco:
+                self.synchronizer.unsubscribe_from_streams()
+            case SessionMode.IntrinsicCalibration:
+                self.synchronizer.unsubscribe_from_streams()
 
+                
     def pause_synchronizer(self):
         logger.info("pausing synchronizer")
-        self.synchronizer.unsubscribe_to_streams()
+        self.synchronizer.unsubscribe_from_streams()
 
     def unpause_synchronizer(self):
         self.synchronizer.subscribe_to_streams()

--- a/pyxy3d/session/session.py
+++ b/pyxy3d/session/session.py
@@ -33,7 +33,7 @@ from pyxy3d.recording.video_recorder import VideoRecorder
 MAX_CAMERA_PORT_CHECK = 10
 FILTERED_FRACTION = 0.05  # by default, 5% of image points with highest reprojection error are filtered out during calibration
 
-class SessionTab(Enum):
+class SessionMode(Enum):
     """
     Note: Not currently being used for anything...if this comment remains for a few days,
     just delete this class, Mac.
@@ -43,7 +43,8 @@ class SessionTab(Enum):
     ExtrinsicCalibration = auto()
     Recording = auto()
     PostProcessing = auto()
-    
+
+ 
 class Session(QObject):
     
     synchronizer_created = pyqtSignal()
@@ -66,6 +67,13 @@ class Session(QObject):
 
         # dictionaries of calibration related objects.
         self.monocalibrators = {}  # key = port
+
+        # store this in the config file and load from configurator      
+        self.recording_fps = 30
+        self.extrinsic_calibration_fps = 6
+        self.monocalibrator_fps = {}
+        
+                
         self.is_recording = False
 
         self.charuco = self.config.get_charuco()

--- a/pyxy3d/session/session.py
+++ b/pyxy3d/session/session.py
@@ -80,6 +80,7 @@ class Session(QObject):
         self.is_recording = False
 
         self.charuco = self.config.get_charuco()
+        self.charuco_tracker = CharucoTracker(self.charuco)
         self.mode = SessionMode.Charuco # default mode of session
          
     
@@ -104,10 +105,10 @@ class Session(QObject):
                     self.pause_all_monocalibrators()
 
             case SessionMode.IntrinsicCalibration:
+                # update in case something has changed
                 self.charuco_tracker = CharucoTracker(self.charuco)
                 
                 if not self.stream_tools_loaded:
-                    self.charuco_tracker = CharucoTracker(self.charuco)
                     self.load_stream_tools()
                 self.synchronizer.unsubscribe_from_streams()
                 self.pause_all_monocalibrators()
@@ -116,21 +117,23 @@ class Session(QObject):
                 self.activate_monocalibrator(self.active_monocalibrator)
 
             case SessionMode.ExtrinsicCalibration:
+                # update in case something has changed
+                self.charuco_tracker = CharucoTracker(self.charuco)
                 if not self.stream_tools_loaded:
-                    self.charuco_tracker = CharucoTracker(self.charuco)
                     self.load_stream_tools()
 
                 self.pause_all_monocalibrators()
                 self.set_streams_charuco()
                 self.set_streams_tracking(True)
                 self.synchronizer.subscribe_to_streams()
+
             case SessionMode.Recording:
                 if not self.stream_tools_loaded:
                     self.load_stream_tools()
 
                 self.pause_all_monocalibrators()
                 self.set_streams_tracking(False)
-                self.set_streams_fps(self.fps_recording)
+                self.update_streams_fps()
                 self.synchronizer.subscribe_to_streams()
 
 

--- a/pyxy3d/session/session.py
+++ b/pyxy3d/session/session.py
@@ -277,13 +277,15 @@ class Session(QObject):
                 logger.info(f"Loading Monocalibrator for port {port}")
                 self.monocalibrators[port] = MonoCalibrator(self.streams[port])
 
-    def activate_monocalibrator(self, active_port:int):
+    def activate_monocalibrator(self, active_port:int=None):
         """
         Used to make sure that only the active camera tab is reading frames during the intrinsic calibration process
         """
 
-        logger.info(f"Activate tracking on port {active_port} and deactivate others")
-        self.active_monocalibrator = active_port
+        if active_port is not None:
+            logger.info(f"Setting session active monocalibrator to {active_port}")
+            self.active_monocalibrator = active_port
+        logger.info(f"Activate tracking on port {self.active_monocalibrator} and deactivate others")
         self.monocalibrators[self.active_monocalibrator].subscribe_to_stream()
 
     def pause_all_monocalibrators(self):

--- a/pyxy3d/session/session.py
+++ b/pyxy3d/session/session.py
@@ -68,10 +68,10 @@ class Session(QObject):
         # dictionaries of calibration related objects.
         self.monocalibrators = {}  # key = port
 
-        # store this in the config file and load from configurator      
-        self.recording_fps = 30
-        self.extrinsic_calibration_fps = 6
-        self.monocalibrator_fps = {}
+        # load fps for various modes
+        self.recording_fps = self.config.get_recording_fps()
+        self.extrinsic_calibration_fps = self.config.get_extrinsic_calibration_fps()
+        self.monocalibrator_fps = self.config.get_intrinsic_calibration_fps()
         
                 
         self.is_recording = False

--- a/pyxy3d/session/session.py
+++ b/pyxy3d/session/session.py
@@ -74,8 +74,9 @@ class Session(QObject):
         self.fps_recording = self.config.get_fps_recording()
         self.fps_extrinsic_calibration = self.config.get_fps_extrinsic_calibration()
         self.fps_intrinsic_calibration = self.config.get_fps_intrinsic_calibration()
+        self.wait_time_extrinsic = self.config.get_extrinsic_wait_time() 
+        self.wait_time_intrinsic = self.config.get_intrinsic_wait_time()
         
-                
         self.is_recording = False
 
         self.charuco = self.config.get_charuco()

--- a/pyxy3d/session/session.py
+++ b/pyxy3d/session/session.py
@@ -136,6 +136,7 @@ class Session(QObject):
     def set_active_mode_fps(self, fps_target:int):
         """
         Updates the FPS used by the currently active session mode
+        This update includes the config.toml
         """
         match self.mode:
             case SessionMode.Charuco:
@@ -144,10 +145,13 @@ class Session(QObject):
                 pass
             case SessionMode.IntrinsicCalibration:
                 self.fps_intrinsic_calibration = fps_target    
+                self.config.save_fps_intrinsic_calibration(fps_target)
             case SessionMode.ExtrinsicCalibration:
                 self.fps_extrinsic_calibration = fps_target
+                self.config.save_fps_extrinsic_calibration(fps_target)
             case SessionMode.Recording:
                 self.fps_recording = fps_target 
+                self.config.save_fps_recording(fps_target)
        
         self.update_streams_fps() 
                 

--- a/tests/test_configurator.py
+++ b/tests/test_configurator.py
@@ -2,6 +2,8 @@
 # are working....
 from pathlib import Path
 import numpy as np
+import os
+import shutil
 
 from pyxy3d import __root__
 from pyxy3d.configurator import Configurator
@@ -45,6 +47,25 @@ def test_configurator():
     new_charuco = config.get_charuco()
     assert(new_charuco.columns==12)
 
+def test_default_config():
+    pass
+
+def remove_all_files_and_folders(directory_path):
+    for item in directory_path.iterdir():
+        if item.is_dir():
+            shutil.rmtree(item)
+        else:
+            item.unlink()
 
 if __name__ == "__main__":
-    test_configurator()
+    # test_configurator()
+    test_path = Path(__root__, "tests", "sessions", "default")
+    remove_all_files_and_folders(test_path)
+    
+    config = Configurator(test_path)
+    
+    
+    
+    # clear out path
+    
+    


### PR DESCRIPTION
Session was expanded to include a SessionMode enum that is used to manage multiple parameters related to the live stream management (monocalibrators, synchronizer, tracking, fps). This allowed a refactor in the GUI code that simplified the transition between different functions/tabs. In addition to making the current code more readable/maintainable, I believe this should enable much faster refactoring of the GUI from its current form (I anticipate this to happen with rapid iteration).