### PR TITLE
376 able to disconnect camera from menu

### DIFF
--- a/pyxy3d/gui/camera_config/intrinsic_calibration_widget.py
+++ b/pyxy3d/gui/camera_config/intrinsic_calibration_widget.py
@@ -14,7 +14,7 @@ from PyQt6.QtWidgets import (
 )
 
 from pyxy3d.gui.camera_config.camera_config_dialogue import CameraConfigTab
-from pyxy3d.session.session import Session, SessionMode, CameraStage
+from pyxy3d.session.session import Session, SessionMode, DataStage
 from pyxy3d.gui.navigation_bars import NavigationBarBackNext
 
 class IntrinsicCalibrationWidget(QWidget):
@@ -26,20 +26,8 @@ class IntrinsicCalibrationWidget(QWidget):
         self.setLayout(QVBoxLayout())    
         self.camera_tabs = CameraTabs(session)
         self.layout().addWidget(self.camera_tabs)
-        # self.navigation_bar = NavigationBarBackNext()
-        # self.layout().addWidget(self.navigation_bar)
     
-        self.camera_tabs.stereoframe_ready.connect(self.set_next_enabled)
-        self.camera_tabs.check_session_calibration()
         self.session = session
-        
-        #prior to entering intrinisc calibration mode, need to have an active monocalibrator
-        # self.session.active_monocalibrator = self.camera_tabs.currentWidget().port
-        # self.session.set_mode(SessionMode.Charuco)
-         
-    def set_next_enabled(self, stereoframe_ready:bool):
-        logger.info(f"Setting camera tab next button enabled status to {stereoframe_ready}")
-        # self.navigation_bar.next_btn.setEnabled(stereoframe_ready)
             
 class CameraTabs(QTabWidget):
     
@@ -99,10 +87,6 @@ class CameraTabs(QTabWidget):
                     pass  # already here, don't bother
                 else:
                     cam_tab = CameraConfigTab(self.session, port)
-                    
-                    # when new camera calibrated, check to see if all cameras calibrated
-                    cam_tab.calibrate_grp.calibration_change.connect(self.check_session_calibration)
-
                     tab_widgets[port] = cam_tab
 
             # add the widgets to the tab bar in order
@@ -111,21 +95,6 @@ class CameraTabs(QTabWidget):
             for port in ordered_ports:
                 self.insertTab(port, tab_widgets[port], f"Camera {port}")
             
-            # session may be pre-calibrated and ready to proceed...or not
-            self.check_session_calibration()
-            
         else:
             logger.info("No cameras available")
         
-        # self.toggle_tracking(self.currentIndex())
-    def check_session_calibration(self):
-        logger.info(f"Checking session stage....")
-        current_stage = self.session.get_camera_stage() 
-        if current_stage == CameraStage.INTRINSICS_ESTIMATED:
-            logger.info("Ready for stereoframe")
-            self.stereoframe_ready.emit(True)       
-        elif current_stage == CameraStage.UNCALIBRATED_CAMERAS:
-            logger.info("Not ready for stereoframe")
-            self.stereoframe_ready.emit(False)
-            
-

--- a/pyxy3d/gui/camera_config/intrinsic_calibration_widget.py
+++ b/pyxy3d/gui/camera_config/intrinsic_calibration_widget.py
@@ -14,7 +14,7 @@ from PyQt6.QtWidgets import (
 )
 
 from pyxy3d.gui.camera_config.camera_config_dialogue import CameraConfigTab
-from pyxy3d.session.session import Session, SessionMode, DataStage
+from pyxy3d.session.session import Session
 from pyxy3d.gui.navigation_bars import NavigationBarBackNext
 
 class IntrinsicCalibrationWidget(QWidget):

--- a/pyxy3d/gui/main_widget.py
+++ b/pyxy3d/gui/main_widget.py
@@ -106,7 +106,25 @@ class MainWindow(QMainWindow):
     def connect_menu_actions(self):
         self.connect_cameras_action.triggered.connect(self.load_stream_tools)
         self.exit_pyxy3d_action.triggered.connect(QApplication.instance().quit)
-    
+        self.disconnect_cameras_action.triggered.connect(self.disconnect_cameras)
+        
+    def disconnect_cameras(self):
+        self.tab_widget.setCurrentWidget(self.charuco_widget)
+        self.tab_widget.setTabEnabled(TabIndex.Charuco.value,True)
+        self.tab_widget.setTabEnabled(TabIndex.Cameras.value,False)
+        self.tab_widget.setTabEnabled(TabIndex.CaptureVolume.value,False)
+        self.tab_widget.setTabEnabled(TabIndex.Recording.value,False)
+        self.tab_widget.setTabEnabled(TabIndex.Processing.value,True)
+        
+        self.camera_widget = QWidget()
+        self.calibrate_capture_volume_widget = QWidget()
+        self.recording_widget = QWidget()
+                
+        self.session.set_mode(SessionMode.Charuco)
+        self.session.disconnect_cameras() 
+        self.disconnect_cameras_action.setEnabled(False)
+        self.connect_cameras_action.setEnabled(True)
+
         
 
     def load_stream_tools(self):
@@ -133,6 +151,7 @@ class MainWindow(QMainWindow):
                     self.calibrate_capture_volume_widget.activate_capture_volume_widget()
                 else:
                     self.calibrate_capture_volume_widget.activate_extrinsic_calibration_widget()
+
             case TabIndex.Recording.value:
                 logger.info(f"Activate Recording Mode")
                 self.session.set_mode(SessionMode.Recording)

--- a/pyxy3d/gui/main_widget.py
+++ b/pyxy3d/gui/main_widget.py
@@ -74,9 +74,8 @@ class MainWindow(QMainWindow):
 
         self.file_menu.addMenu(self.open_recent_project_submenu)
 
-        self.close_session_action = QAction("Close Session", self)
-        # self.close_session_action.triggered.connect(self.close_current_session)
-        self.file_menu.addAction(self.close_session_action)
+        self.exit_pyxy3d_action = QAction("Exit", self)
+        self.file_menu.addAction(self.exit_pyxy3d_action)
 
         self.cameras_menu = self.menu.addMenu("Cameras")
         self.connect_cameras_action = QAction("Connect Cameras", self)
@@ -90,8 +89,6 @@ class MainWindow(QMainWindow):
         self.connect_menu_actions()
 
         # Set up layout (based on splitter)
-        # central_widget = QWidget(self)
-
         self.tab_widget = QTabWidget()
         self.setCentralWidget(self.tab_widget)
 
@@ -104,8 +101,13 @@ class MainWindow(QMainWindow):
 
         self.addDockWidget(Qt.DockWidgetArea.BottomDockWidgetArea, self.docked_logger)
 
+
+
     def connect_menu_actions(self):
         self.connect_cameras_action.triggered.connect(self.load_stream_tools)
+        self.exit_pyxy3d_action.triggered.connect(QApplication.instance().quit)
+    
+        
 
     def load_stream_tools(self):
         self.connect_cameras_action.setEnabled(False)

--- a/pyxy3d/session/session.py
+++ b/pyxy3d/session/session.py
@@ -43,18 +43,20 @@ class SessionMode(Enum):
     Recording = auto()
     PostProcessing = auto()
 
-class DataStage(Enum):
-    NO_CAMERAS = auto()
-    UNCALIBRATED_CAMERAS = auto()
-    INTRINSICS_IN_PROCESES = auto()
-    INTRINSICS_ESTIMATED = auto()
-    EXTRINSICS_ESTIMATED = auto()
-    ORIGIN_SET = auto()
-    RECORDINGS_SAVED = auto()
+# class DataStage(Enum):
+#     NO_CAMERAS = auto()
+#     UNCALIBRATED_CAMERAS = auto()
+#     INTRINSICS_IN_PROCESES = auto()
+#     INTRINSICS_ESTIMATED = auto()
+#     EXTRINSICS_ESTIMATED = auto()
+#     ORIGIN_SET = auto()
+#     RECORDINGS_SAVED = auto()
 
 class Session(QObject):
     stream_tools_loaded_signal = pyqtSignal()
+    stream_tools_disconnected_signal = pyqtSignal()
     unlock_postprocessing = pyqtSignal()
+
     mode_change_success = pyqtSignal(SessionMode)
 
     def __init__(self, config: Configurator):
@@ -92,33 +94,49 @@ class Session(QObject):
         self.mode = SessionMode.Charuco  # default mode of session
 
 ################
-    def get_camera_stage(self):
-        stage = None
-        connected_camera_count = len(self.cameras)
-        calibrated_camera_count = 0
-        for key in self.config.dict.keys():
-            if key.startswith("cam"):
-                if "error" in self.config.dict[key].keys():
-                    if self.config.dict[key]["error"] is not None:
-                        calibrated_camera_count += 1
+    # def get_stage(self):
+    #     stage = None
+    #     connected_camera_count = len(self.cameras)
+    #     calibrated_camera_count = 0
+    #     for key in self.config.dict.keys():
+    #         if key.startswith("cam"):
+    #             if "error" in self.config.dict[key].keys():
+    #                 if self.config.dict[key]["error"] is not None:
+    #                     calibrated_camera_count += 1
 
-        if connected_camera_count == 0:
-            stage = DataStage.NO_CAMERAS
+    #     if connected_camera_count == 0:
+    #         stage = DataStage.NO_CAMERAS
 
-        elif calibrated_camera_count < connected_camera_count:
-            stage = DataStage.UNCALIBRATED_CAMERAS
+    #     elif calibrated_camera_count < connected_camera_count:
+    #         stage = DataStage.UNCALIBRATED_CAMERAS
 
-        elif (
-            connected_camera_count > 0
-            and calibrated_camera_count == connected_camera_count
-        ):
-            stage = DataStage.INTRINSICS_ESTIMATED
+    #     elif (
+    #         connected_camera_count > 0
+    #         and calibrated_camera_count == connected_camera_count
+    #     ):
+    #         stage = DataStage.INTRINSICS_ESTIMATED
 
-        return stage
+    #     return stage
 
-
-
-    
+    def disconnect_cameras(self):
+        """
+        Shut down the streams, close the camera captures and delete the monocalibrators and synchronizer
+        """
+        for port, stream in self.streams.items():
+            stream.stop_event.set()
+        self.streams = {}
+        for port, cam in self.cameras.items():
+            cam.disconnect()
+        self.cameras = {}
+        for port, monocal in self.monocalibrators.items():
+            monocal.stop_event.set()
+        self.monocalibrators = {} 
+        self.synchronizer.stop_event.set()
+        self.synchronizer = None
+        
+        self.stream_tools_disconnected_signal.emit()
+        
+        
 ######################
 
 

--- a/pyxy3d/session/session.py
+++ b/pyxy3d/session/session.py
@@ -36,7 +36,6 @@ FILTERED_FRACTION = 0.05  # by default, 5% of image points with highest reprojec
 class SessionMode(Enum):
     """
     """
-
     Charuco = auto()
     IntrinsicCalibration = auto()
     ExtrinsicCalibration = auto()
@@ -44,14 +43,14 @@ class SessionMode(Enum):
     Recording = auto()
     PostProcessing = auto()
 
-class CameraStage(Enum):
+class DataStage(Enum):
     NO_CAMERAS = auto()
     UNCALIBRATED_CAMERAS = auto()
     INTRINSICS_IN_PROCESES = auto()
     INTRINSICS_ESTIMATED = auto()
     EXTRINSICS_ESTIMATED = auto()
     ORIGIN_SET = auto()
-    # RECORDINGS_SAVED = auto()
+    RECORDINGS_SAVED = auto()
 
 class Session(QObject):
     stream_tools_loaded_signal = pyqtSignal()
@@ -104,16 +103,16 @@ class Session(QObject):
                         calibrated_camera_count += 1
 
         if connected_camera_count == 0:
-            stage = CameraStage.NO_CAMERAS
+            stage = DataStage.NO_CAMERAS
 
         elif calibrated_camera_count < connected_camera_count:
-            stage = CameraStage.UNCALIBRATED_CAMERAS
+            stage = DataStage.UNCALIBRATED_CAMERAS
 
         elif (
             connected_camera_count > 0
             and calibrated_camera_count == connected_camera_count
         ):
-            stage = CameraStage.INTRINSICS_ESTIMATED
+            stage = DataStage.INTRINSICS_ESTIMATED
 
         return stage
 


### PR DESCRIPTION
GUI updates working well. Getting a clearer sense of how to manage the mode switch. Don't need to track CameraStage (or DataStage or SessionStage, or whatever I was calling it). I just need to have a way to calculate if a given stage is eligible to move into, and those can just be bespoke Session.methods. 

Might be better off in the future to just destroy and recreate the camera dependent widgets when moving off and on to them...Not sure if this will reduce background overhead, but really, why would I need to keep that reference, and with the stream tools loaded, the new widgets are cheap to make...