### PR TITLE
373 capture volume enabled by intrinsic cal

### DIFF
--- a/dev/demo/demo_gui_main.py
+++ b/dev/demo/demo_gui_main.py
@@ -13,13 +13,7 @@ recent_project_count = len(recent_projects)
 session_path = Path(recent_projects[recent_project_count - 1])
 
 app = QApplication(sys.argv)
-# app = QApplication([])
-
 window = MainWindow()
-
 window.launch_session(str(session_path))
-
-
 window.show()
-
 app.exec()

--- a/pyxy3d/calibration/capture_volume/capture_volume.py
+++ b/pyxy3d/calibration/capture_volume/capture_volume.py
@@ -74,15 +74,13 @@ class CaptureVolume:
         return rmse
 
     def get_rmse_summary(self):
-        
-        rmse_string = f"\nRMSE of Reprojection\n"
-        rmse_string+= f"    Overall: {round(self.rmse['overall'],2)}\n"
+        rmse_string = f"RMSE of Reprojection Overall: {round(self.rmse['overall'],2)}\n"
         rmse_string+= "    by camera:\n"
         for key, value in self.rmse.items():
             if key == "overall":
                 pass
             else:
-                rmse_string+=f"{key: >9}: {round(float(value),2)} \n"
+                rmse_string+=f"    {key: >9}: {round(float(value),2)}\n"
 
         return rmse_string
         

--- a/pyxy3d/configurator.py
+++ b/pyxy3d/configurator.py
@@ -31,9 +31,7 @@ class Configurator:
         self.toml_path = Path(self.session_path,"config.toml")
         
         if exists(self.toml_path):
-            logger.info("Found previous config")
-            with open(self.toml_path, "r") as f:
-                self.dict = toml.load(self.toml_path)
+            self.refresh_from_toml()
         else:
             logger.info(
                 "No existing config.toml found; creating starter file with charuco"
@@ -92,6 +90,13 @@ class Configurator:
         self.dict["fps_intrinsic_calibration"]  = fps 
         self.update_toml()
 
+
+    def refresh_from_toml(self):
+        logger.info("Populating config dictionary with config.toml data")
+        with open(self.toml_path, "r") as f:
+            self.dict = toml.load(self.toml_path)
+        
+        
     def update_toml(self):
         # alphabetize by key to maintain standardized layout
         sorted_dict = {key: value for key, value in sorted(self.dict.items())}
@@ -100,15 +105,6 @@ class Configurator:
         with open(self.toml_path, "w") as f:
             toml.dump(self.dict, f)
 
-    # session loads capture volume in pieces
-    # also creates quality controller
-    # delete this code if you see it commented out still
-    # def get_capture_volume(self)->CaptureVolume:
-    #     camera_array = self.get_camera_array()
-    #     point_estimates = self.get_point_estimates()
-        
-    #     capture_volume = CaptureVolume(camera_array,point_estimates)
-    #     return capture_volume
     
     def save_capture_volume(self, capture_volume:CaptureVolume):
         # self.point_estimates = self.capture_volume.point_estimates

--- a/pyxy3d/gui/calibrate_capture_volume_widget.py
+++ b/pyxy3d/gui/calibrate_capture_volume_widget.py
@@ -48,9 +48,12 @@ class CalibrateCaptureVolumeWidget(QStackedWidget):
         self.session = session
 
         if self.session.capture_volume_eligible():
+            logger.info("able to load Capture Volume, proceeeding with load of capture volume widget")
             self.activate_capture_volume_widget()
         else:
+            logger.info("Unable to load capture volume from config; load extrinsic calibration widget")
             self.activate_extrinsic_calibration_widget()
+
     ###################### Stereocalibration  ######################################
     def activate_extrinsic_calibration_widget(self):
         logger.info(f"Setting session mode to {SessionMode.ExtrinsicCalibration} from within subwidget")

--- a/pyxy3d/gui/calibrate_capture_volume_widget.py
+++ b/pyxy3d/gui/calibrate_capture_volume_widget.py
@@ -88,7 +88,7 @@ class CalibrateCaptureVolumeWidget(QStackedWidget):
         self.addWidget(self.capture_volume_widget)
         self.setCurrentWidget(self.capture_volume_widget)
 
-        self.capture_volume_widget.navigation_bar.back_btn.clicked.connect(
+        self.capture_volume_widget.recalibrate_btn.clicked.connect(
             self.activate_extrinsic_calibration_widget
         )
         

--- a/pyxy3d/gui/main_widget.py
+++ b/pyxy3d/gui/main_widget.py
@@ -173,19 +173,8 @@ class MainWindow(QMainWindow):
         # launches without cameras connected, so just throw in placeholders
         self.camera_widget = QWidget()
         self.recording_widget = QWidget()
-
-        # need to check whether some offline tasks are available now...
-        if self.session.post_processing_eligible():
-            self.processing_widget = PostProcessingWidget(self.session)
-        else:
-            self.processing_widget = QWidget()
-
-        if self.session.capture_volume_eligible():
-            self.calibrate_capture_volume_widget = CalibrateCaptureVolumeWidget(
-                self.session
-            )
-        else:
-            self.calibrate_capture_volume_widget = QWidget()
+        self.processing_widget = QWidget()
+        self.calibrate_capture_volume_widget = QWidget()
 
         self.tab_widget.addTab(self.charuco_widget, "Charuco")
         self.tab_widget.addTab(self.camera_widget, "Cameras")
@@ -196,9 +185,13 @@ class MainWindow(QMainWindow):
         # when tabs change, make sure session mode adjusts
         self.tab_widget.currentChanged.connect(self.on_tab_changed)
 
-        # Default to having ability to search out stream tools
+        # Make sure file menu can allow camera connection action
         self.connect_cameras_action.setEnabled(True)
+        
+        # based on session parameters, may be able to load more than the defualt tabs
+        # check on that now...
         self.update_tabs()
+
         # might be able to do
         old_index = self.tab_widget.currentIndex()
 
@@ -237,20 +230,9 @@ class MainWindow(QMainWindow):
             self.tab_widget.setTabEnabled(TabIndex.Recording.value, False)
             self.tab_widget.setTabEnabled(TabIndex.CaptureVolume.value, False)
 
-        # might be able to fiddle with the capture volume origin
-        # if self.session.capture_volume_eligible():
-        #     if (
-        #         type(self.calibrate_capture_volume_widget)
-        #         != CalibrateCaptureVolumeWidget
-        #     ):
-        #         self.load_capture_volume_widget()
-
-        #     self.tab_widget.setTabEnabled(TabIndex.CaptureVolume.value, True)
-        # else:
-        #     self.tab_widget.setTabEnabled(TabIndex.CaptureVolume.value, False)
-
         # might be able to do post processing if recordings and calibration available
         if self.session.post_processing_eligible():
+            self.load_post_processing_widget()
             self.tab_widget.setTabEnabled(TabIndex.Processing.value, True)
         else:
             self.tab_widget.setTabEnabled(TabIndex.Processing.value, False)

--- a/pyxy3d/gui/main_widget.py
+++ b/pyxy3d/gui/main_widget.py
@@ -148,9 +148,16 @@ class MainWindow(QMainWindow):
                 logger.info(f"Activating Calibrate Capture Volume Widget")
 
                 if self.session.capture_volume_eligible():
+                    logger.info(f"Session is eligible for setting of origin...activating capture volume origin widget")
                     self.calibrate_capture_volume_widget.activate_capture_volume_widget()
                 else:
+                    logger.info(f"Session is not eligible for setting of origin...activating extrinsic calibration widget")
                     self.calibrate_capture_volume_widget.activate_extrinsic_calibration_widget()
+
+                    if self.session.extrinsic_calibration_eligible():
+                        self.calibrate_capture_volume_widget.extrinsic_calibration_widget.calibrate_collect_btn.setEnabled(True)
+                    else:
+                        self.calibrate_capture_volume_widget.extrinsic_calibration_widget.calibrate_collect_btn.setEnabled(False)
 
             case TabIndex.Recording.value:
                 logger.info(f"Activate Recording Mode")
@@ -225,6 +232,9 @@ class MainWindow(QMainWindow):
             self.tab_widget.setTabEnabled(TabIndex.Cameras.value, True)
             self.tab_widget.setTabEnabled(TabIndex.Recording.value, True)
             self.tab_widget.setTabEnabled(TabIndex.CaptureVolume.value, True)
+        
+
+
         else:
             self.tab_widget.setTabEnabled(TabIndex.Cameras.value, False)
             self.tab_widget.setTabEnabled(TabIndex.Recording.value, False)

--- a/pyxy3d/gui/main_widget.py
+++ b/pyxy3d/gui/main_widget.py
@@ -225,24 +225,29 @@ class MainWindow(QMainWindow):
 
             if type(self.recording_widget) != RecordingWidget:
                 self.load_recording_widget()
+            
+            if type(self.calibrate_capture_volume_widget) != CalibrateCaptureVolumeWidget:
+                self.load_capture_volume_widget()
 
             self.tab_widget.setTabEnabled(TabIndex.Cameras.value, True)
             self.tab_widget.setTabEnabled(TabIndex.Recording.value, True)
+            self.tab_widget.setTabEnabled(TabIndex.CaptureVolume.value, True)
         else:
             self.tab_widget.setTabEnabled(TabIndex.Cameras.value, False)
             self.tab_widget.setTabEnabled(TabIndex.Recording.value, False)
+            self.tab_widget.setTabEnabled(TabIndex.CaptureVolume.value, False)
 
         # might be able to fiddle with the capture volume origin
-        if self.session.capture_volume_eligible():
-            if (
-                type(self.calibrate_capture_volume_widget)
-                != CalibrateCaptureVolumeWidget
-            ):
-                self.load_capture_volume_widget()
+        # if self.session.capture_volume_eligible():
+        #     if (
+        #         type(self.calibrate_capture_volume_widget)
+        #         != CalibrateCaptureVolumeWidget
+        #     ):
+        #         self.load_capture_volume_widget()
 
-            self.tab_widget.setTabEnabled(TabIndex.CaptureVolume.value, True)
-        else:
-            self.tab_widget.setTabEnabled(TabIndex.CaptureVolume.value, False)
+        #     self.tab_widget.setTabEnabled(TabIndex.CaptureVolume.value, True)
+        # else:
+        #     self.tab_widget.setTabEnabled(TabIndex.CaptureVolume.value, False)
 
         # might be able to do post processing if recordings and calibration available
         if self.session.post_processing_eligible():
@@ -284,11 +289,11 @@ class MainWindow(QMainWindow):
         self.calibrate_capture_volume_widget.deleteLater()
         new_capture_volume_widget = CalibrateCaptureVolumeWidget(self.session)
         self.tab_widget.insertTab(
-            TabIndex.Cameras.value,
+            TabIndex.CaptureVolume.value,
             new_capture_volume_widget,
             TabIndex.CaptureVolume.name,
         )
-        self.camera_widget = new_capture_volume_widget
+        self.calibrate_capture_volume_widget = new_capture_volume_widget
 
     def load_camera_widget(self):
         self.tab_widget.removeTab(TabIndex.Cameras.value)
@@ -298,6 +303,9 @@ class MainWindow(QMainWindow):
             TabIndex.Cameras.value, new_camera_widget, TabIndex.Cameras.name
         )
         self.camera_widget = new_camera_widget
+        
+        # if fully calibrated, then make capture volume available
+        # self.camera_widget.camera_tabs.stereoframe_ready.connect(self.update_tabs)
 
     def add_to_recent_project(self, project_path: str):
         recent_project_action = QAction(project_path, self)

--- a/pyxy3d/gui/vizualize/calibration/capture_volume_widget.py
+++ b/pyxy3d/gui/vizualize/calibration/capture_volume_widget.py
@@ -39,6 +39,10 @@ class CaptureVolumeWidget(QWidget):
         super(CaptureVolumeWidget, self).__init__()
 
         self.session = session
+
+        if not hasattr(self.session, "capture_volume"):
+            self.session.load_estimated_capture_volume()
+            
         self.visualizer = CaptureVolumeVisualizer(self.session.capture_volume)
         # self.visualizer.scene.show()
         self.slider = QSlider(Qt.Orientation.Horizontal)

--- a/pyxy3d/gui/vizualize/calibration/capture_volume_widget.py
+++ b/pyxy3d/gui/vizualize/calibration/capture_volume_widget.py
@@ -55,11 +55,10 @@ class CaptureVolumeWidget(QWidget):
         self.rotate_z_plus_btn = QPushButton("Z+")
         self.rotate_z_minus_btn = QPushButton("Z-")
 
-        self.distance_error_summary = QLabel(self.session.quality_controller.distance_error_summary.to_string(index=False))
+        # self.distance_error_summary = QLabel(self.session.quality_controller.distance_error_summary.to_string(index=False))
         self.rmse_summary = QLabel(self.session.capture_volume.get_rmse_summary())
-        
-
-        self.navigation_bar = NavigationBarBack()
+       
+        self.recalibrate_btn = QPushButton("Recalibrate") 
 
         self.place_widgets()
         self.connect_widgets()
@@ -69,13 +68,10 @@ class CaptureVolumeWidget(QWidget):
     def place_widgets(self):
         self.setLayout(QVBoxLayout())
         self.layout().addWidget(self.visualizer.scene, stretch=2)
-        self.visualizer.scene.setMinimumHeight(400)
         self.layout().addWidget(self.slider)
-        self.layout().addWidget(self.set_origin_btn)
     
 
         self.grid = QGridLayout()
-        self.layout().addLayout(self.grid)
         self.grid.addWidget(self.rotate_x_plus_btn, 0, 0)
         self.grid.addWidget(self.rotate_x_minus_btn, 1, 0)
         self.grid.addWidget(self.rotate_y_plus_btn, 0, 1)
@@ -83,14 +79,22 @@ class CaptureVolumeWidget(QWidget):
         self.grid.addWidget(self.rotate_z_plus_btn, 0, 2)
         self.grid.addWidget(self.rotate_z_minus_btn, 1, 2)
 
-        # thie distance error summary here is ugly and needs to be in a table,
-        # But thats out of scope for my current objectives.
-        self.hbox_summary = QHBoxLayout()
-        self.hbox_summary.addWidget(self.rmse_summary)  
-        self.hbox_summary.addWidget(self.distance_error_summary)  
-        self.layout().addLayout(self.hbox_summary)
-
-        self.layout().addWidget(self.navigation_bar)
+        self.world_origin_group = QGroupBox()
+        self.world_origin_group.setLayout(QVBoxLayout())
+        self.world_origin_group.layout().addWidget(self.set_origin_btn)
+        self.world_origin_group.layout().addLayout(self.grid)
+        
+        self.calibrate_group = QGroupBox()
+        self.calibrate_group.setLayout(QVBoxLayout())
+        self.calibrate_group.layout().addWidget(self.rmse_summary)
+        self.calibrate_group.layout().addWidget(self.recalibrate_btn)
+        
+        self.hbox = QHBoxLayout()
+        self.hbox.addWidget(self.calibrate_group)
+        self.hbox.addWidget(self.world_origin_group)
+        self.layout().addLayout(self.hbox)
+        
+        # self.layout().addWidget(self.recalibrate_btn)
 
 
     def connect_widgets(self):

--- a/pyxy3d/gui/vizualize/playback_triangulation_widget.py
+++ b/pyxy3d/gui/vizualize/playback_triangulation_widget.py
@@ -138,7 +138,7 @@ class TriangulationVisualizer:
 
             current_sync_index_flag = self.sync_indices == self.sync_index
             self.points = self.xyz_coord[current_sync_index_flag]
-            logger.info(f"Displaying xyz points for sync index {sync_index}")
+            logger.debug(f"Displaying xyz points for sync index {sync_index}")
             self.scatter.setData(pos=self.points)
 
         else: 

--- a/pyxy3d/post_processor.py
+++ b/pyxy3d/post_processor.py
@@ -103,7 +103,7 @@ class PostProcessor(QObject):
         while video_recorder.recording:
             sleep(1)
             percent_complete = int((video_recorder.sync_index / sync_index_count) * 100)
-            logger.info(f"{percent_complete}% processed")
+            logger.info(f"(Stage 1 of 2): {percent_complete}% of frames processed for (x,y) landmark detection")
             self.progress_update.emit(
                 {
                     "stage": "Estimating (x,y) landmark positions (stage 1 of 2)",
@@ -160,7 +160,7 @@ class PostProcessor(QObject):
             if int(time()) - last_log_update >= 1:
                 percent_complete = int(100*(index/sync_index_max))
                 logger.info(
-                    f"Triangulation of (x,y) point estimates is {percent_complete}% complete"
+                    f"(Stage 2 of 2): Triangulation of (x,y) point estimates is {percent_complete}% complete"
                 )
                 last_log_update = int(time())
                 self.progress_update.emit(

--- a/pyxy3d/recording/video_recorder.py
+++ b/pyxy3d/recording/video_recorder.py
@@ -86,9 +86,9 @@ class VideoRecorder(QObject):
         while self.sync_packet_in_q.qsize() > 0 or not self.trigger_stop.is_set(): 
             sync_packet: SyncPacket = self.sync_packet_in_q.get()
 
-
             # provide periodic updates of recording queue
-            if self.sync_packet_in_q.qsize() % 25 ==0:
+            backlog = self.sync_packet_in_q.qsize()
+            if backlog % 25 == 0 and backlog !=0:
                 logger.info(f"Size of unsaved frames on the recording queue is {self.sync_packet_in_q.qsize()}")
 
             if sync_packet is None:

--- a/pyxy3d/session/session.py
+++ b/pyxy3d/session/session.py
@@ -126,6 +126,7 @@ class Session(QObject):
     def extrinsic_calibration_eligible(self):
 
         # assume it is and prove if it's not
+        self.config.refresh_from_toml()
         self.camera_array = self.config.get_camera_array()
         eligible = True
         for port, cam in self.camera_array.cameras.items():
@@ -141,7 +142,8 @@ class Session(QObject):
         and there is a capture volume loaded up, then you can launch direct
         into the capture volume widget rather than the extrinsic calibration widget
         """
-
+        
+        self.config.refresh_from_toml()
         self.camera_array = self.config.get_camera_array()
         # assume it is and prove if it's not
         eligible = True
@@ -161,8 +163,11 @@ class Session(QObject):
         
         """
         #assume true and prove otherwise
+        self.config.refresh_from_toml()
+        self.camera_array = self.config.get_camera_array()
+
         has_extrinsics = True
-        for port, camera in self.cameras.items():
+        for port, camera in self.camera_array.cameras.items():
             if camera.ignore == False and (
                 camera.rotation is None or camera.translation is None
             ):

--- a/pyxy3d/session/session.py
+++ b/pyxy3d/session/session.py
@@ -93,30 +93,6 @@ class Session(QObject):
         self.charuco_tracker = CharucoTracker(self.charuco)
         self.mode = SessionMode.Charuco  # default mode of session
 
-################
-    # def get_stage(self):
-    #     stage = None
-    #     connected_camera_count = len(self.cameras)
-    #     calibrated_camera_count = 0
-    #     for key in self.config.dict.keys():
-    #         if key.startswith("cam"):
-    #             if "error" in self.config.dict[key].keys():
-    #                 if self.config.dict[key]["error"] is not None:
-    #                     calibrated_camera_count += 1
-
-    #     if connected_camera_count == 0:
-    #         stage = DataStage.NO_CAMERAS
-
-    #     elif calibrated_camera_count < connected_camera_count:
-    #         stage = DataStage.UNCALIBRATED_CAMERAS
-
-    #     elif (
-    #         connected_camera_count > 0
-    #         and calibrated_camera_count == connected_camera_count
-    #     ):
-    #         stage = DataStage.INTRINSICS_ESTIMATED
-
-    #     return stage
 
     def disconnect_cameras(self):
         """
@@ -147,6 +123,32 @@ class Session(QObject):
             eligible = False
         return eligible
 
+    def extrinsic_calibration_eligible(self):
+
+        # assume it is and prove if it's not
+        eligible = True
+        for port, cam in self.cameras.items():
+            if cam.matrix is None or cam.distortions is None:
+                eligible = False
+                
+        return eligible
+        
+
+    def capture_volume_eligible(self):
+        """
+        if all cameras that are not ignored have rotation and translation not None
+        and there is a capture volume loaded up, then you can launch direct
+        into the capture volume widget rather than the extrinsic calibration widget
+        """
+
+        # assume it is and prove if it's not
+        eligible = True
+        for port, cam in self.cameras.items():
+            if cam.rotation is None or cam.translation is None:
+                eligible = False
+                
+        return eligible
+
     def start_recording_eligible(self):
         """
         Used to determine if the Record Button is enabled
@@ -168,24 +170,8 @@ class Session(QObject):
             eligible = False
 
         return eligible
-
-    def capture_volume_eligible(self):
-        """
-        if all cameras that are not ignored have rotation and translation not None
-        and there is a capture volume loaded up, then you can launch direct
-        into the capture volume widget rather than the extrinsic calibration widget
-        """
-
-        # If not able to load, then not eligible
-        try: 
-            self.load_estimated_capture_volume()
-            eligible = True
-        except:
-            eligible = False
         
-        return eligible
         
-
     def post_processing_eligible(self):
         """
         Post processing can only be performed if recordings exist and extrinsics are calibrated
@@ -201,6 +187,7 @@ class Session(QObject):
             eligible = False            
 
         return eligible
+   
     
     def set_mode(self, mode: SessionMode):
         """

--- a/pyxy3d/session/session.py
+++ b/pyxy3d/session/session.py
@@ -126,8 +126,9 @@ class Session(QObject):
     def extrinsic_calibration_eligible(self):
 
         # assume it is and prove if it's not
+        self.camera_array = self.config.get_camera_array()
         eligible = True
-        for port, cam in self.cameras.items():
+        for port, cam in self.camera_array.cameras.items():
             if cam.matrix is None or cam.distortions is None:
                 eligible = False
                 
@@ -141,12 +142,17 @@ class Session(QObject):
         into the capture volume widget rather than the extrinsic calibration widget
         """
 
+        self.camera_array = self.config.get_camera_array()
         # assume it is and prove if it's not
         eligible = True
-        for port, cam in self.cameras.items():
+        for port, cam in self.camera_array.cameras.items():
             if cam.rotation is None or cam.translation is None:
                 eligible = False
-                
+                logger.info(f"Failed capture volume eligibility due to camera {port}: {cam.__dict__}")
+        
+        logger.info(f"Eligible to load capture volume? (i.e. fully calibrated extrinsics): {eligible}") 
+
+
         return eligible
 
     def start_recording_eligible(self):


### PR DESCRIPTION
Session eligibility being used to set the active capture volume widget as well as the enablement of the button for collect extrinsic calibration data.

In general, improved methods for each eligibility stage as well as more timely refreshing of the session.config.dict from the config.toml file are now included with this branch.