### PR TITLE
404 changing exposure deletes translation and rotation

### DIFF
--- a/pyxy3d/configurator.py
+++ b/pyxy3d/configurator.py
@@ -312,18 +312,6 @@ class Configurator:
 
         self.update_toml()
 
-
-    # def get_live_stream_pool(self, tracker:Tracker = None):
-    #     streams = {}
-    #     cameras = self.get_cameras()
-
-    #     for port, cam in cameras.items():
-    #         logger.info(f"Adding stream associated with camera {port}")
-    #         stream = LiveStream(cam, tracker=tracker)
-    #         stream.change_resolution(cam.size)
-    #         streams[port] = stream
-    #     return streams            
-
     
      
 if __name__ == "__main__":

--- a/pyxy3d/configurator.py
+++ b/pyxy3d/configurator.py
@@ -279,15 +279,19 @@ class Configurator:
                 camera.rotation_count = params["rotation_count"]
                 camera.exposure = params["exposure"]
 
-                # if calibration done, then populate those as well
-                if "error" in params.keys():
+                if "error" in params.keys(): # then intrinsic params available
+                    # if calibration done, then populate those as well
+                    logger.info(f"Adding in preconfigured intrinsic params at port {port}")
                     logger.info(f"Camera RMSE error for port {port}: {params['error']}")
                     camera.error = params["error"]
                     camera.matrix = np.array(params["matrix"]).astype(float)
                     camera.distortions = np.array(params["distortions"]).astype(float)
                     camera.grid_count = params["grid_count"]
-            # except:
-            #     logger.info("Unable to connect... camera may be in use.")
+
+                if "rotation" in params.keys(): # then extrinsic params available
+                    logger.info(f"Adding in preconfigured extrinsic params at port {port}")
+                    camera.rotation = cv2.Rodrigues(np.array(params["rotation"]))[0]
+                    camera.translation = np.array(params["translation"])
 
         with ThreadPoolExecutor() as executor:
             for key, params in self.dict.items():


### PR DESCRIPTION
error was caused by configurator failing to load extrinsic camera parameters that had been pre-configured. Ultimately, this was causing the .toml parameters to be overwritten as None when exposure was changed on a reloaded camera that hadn't undergone extrinsic cal within the session. Based on brief testing, it seems that this has also resolved the segfault errors that cropped up. I believe the capture volume was essentially getting destroyed when the exposure setting was updated, so everything went to hell.

There's a lesson in here, but I have no idea what it is at the moment....'be careful", perhaps?