### PR TITLE
432 add metarig config button to post processing

### DIFF
--- a/pyxy3d/gui/post_processing_widget.py
+++ b/pyxy3d/gui/post_processing_widget.py
@@ -37,6 +37,7 @@ from PyQt6.QtWidgets import (
 )
 
 from pyxy3d.post_processing.post_processor import PostProcessor
+from pyxy3d.post_processing.blender_tools import generate_metarig_config
 from pyxy3d.session.session import Session
 from pyxy3d.cameras.synchronizer import Synchronizer
 from pyxy3d import __root__
@@ -72,7 +73,6 @@ class PostProcessingWidget(QWidget):
                 
 
         self.tracker_combo = QComboBox()
-
         self.vizualizer_title = QLabel()
 
         # Add items to the combo box using the name attribute of the TrackerEnum
@@ -80,10 +80,11 @@ class PostProcessingWidget(QWidget):
             if tracker.name != "CHARUCO":
                 self.tracker_combo.addItem(tracker.name, tracker)
 
-        self.process_current_btn = QPushButton("&Process")
-        # self.export_btn = QPushButton("&Export")
-        self.open_folder_btn = QPushButton("&Open Folder")
 
+
+        self.open_folder_btn = QPushButton("&Open Folder")
+        self.process_current_btn = QPushButton("&Process")
+        self.generate_metarig_config_btn = QPushButton("Generate Metarig Config")
         self.refresh_visualizer() # must happen before placement to create vis_widget and vizualizer_title
         self.place_widgets()
         self.connect_widgets()
@@ -128,6 +129,13 @@ class PostProcessingWidget(QWidget):
         file_name = f"xyz_{self.tracker_combo.currentData().name}.csv"
         result = Path(self.processed_subfolder, file_name)
         return result
+
+    @property
+    def metarig_config_path(self):
+        file_name = f"metarig_config_{self.tracker_combo.currentData().name}.json"
+        result = Path(self.processed_subfolder, file_name)
+        return result
+        
 
     def current_selection_processed(self) -> bool:
         """ "
@@ -176,7 +184,7 @@ class PostProcessingWidget(QWidget):
         self.left_vbox.addWidget(self.open_folder_btn)
         self.left_vbox.addWidget(self.tracker_combo)
         self.button_hbox.addWidget(self.process_current_btn)
-        # self.button_hbox.addWidget(self.export_btn)
+        self.button_hbox.addWidget(self.generate_metarig_config_btn)
         self.left_vbox.addLayout(self.button_hbox)
 
         self.layout().addLayout(self.right_vbox, stretch=2)
@@ -189,7 +197,8 @@ class PostProcessingWidget(QWidget):
         self.vis_widget.slider.valueChanged.connect(self.store_sync_index_cursor)
         self.process_current_btn.clicked.connect(self.process_current)
         self.open_folder_btn.clicked.connect(self.open_folder)
-        # self.export_btn.clicked.connect(self.export_current_file)
+        self.generate_metarig_config_btn.clicked.connect(self.create_metarig_config)
+
         self.processing_complete.connect(self.enable_all_inputs)
         self.processing_complete.connect(self.refresh_visualizer)
 
@@ -243,7 +252,14 @@ class PostProcessingWidget(QWidget):
         thread = Thread(target=processing_worker, args=(), daemon=True)
         thread.start()
 
+    def create_metarig_config(self):
+        logger.info(f"Beginning metarig_config creation in {self.processed_subfolder}")
+        tracker_enum = self.tracker_combo.currentData()
+        xyz_csv_path = Path(self.processed_subfolder, f"xyz_{tracker_enum.name}_labelled.csv")
+        generate_metarig_config(tracker_enum, xyz_csv_path)
 
+        self.update_enabled_disabled()
+        
     def refresh_visualizer(self):
         # logger.info(f"Item {item.text()} selected and double-clicked.")
         active_config = Configurator(self.active_recording_path)
@@ -272,20 +288,25 @@ class PostProcessingWidget(QWidget):
         """
         self.recording_folders.setEnabled(True)
         self.tracker_combo.setEnabled(True)
-        # self.export_btn.setEnabled(True)
         self.process_current_btn.setEnabled(True)
         self.vis_widget.slider.setEnabled(True)
 
     def update_enabled_disabled(self):
+
         if self.processed_xyz_path.exists():
-            # self.export_btn.setEnabled(True)
             self.process_current_btn.setEnabled(False)
             self.vis_widget.slider.setEnabled(True)
-
+            
+            # must have xyz params to be able to generate metarig config
+            if self.metarig_config_path.exists():
+                self.generate_metarig_config_btn.setEnabled(False)
+            else:
+                self.generate_metarig_config_btn.setEnabled(True)
+                
         else:
-            # self.export_btn.setEnabled(False)
             self.process_current_btn.setEnabled(True)
             self.vis_widget.slider.setEnabled(False)
+            self.generate_metarig_config_btn.setEnabled(False)
 
     def update_slider_position(self):
         # update slider value to stored value if it exists
@@ -295,6 +316,7 @@ class PostProcessingWidget(QWidget):
             self.vis_widget.visualizer.display_points(active_sync_index)
         else:
             pass
+
 
 
 

--- a/pyxy3d/gui/post_processing_widget.py
+++ b/pyxy3d/gui/post_processing_widget.py
@@ -293,20 +293,21 @@ class PostProcessingWidget(QWidget):
 
     def update_enabled_disabled(self):
 
+        # set availability of metarig generation 
+        tracker = self.tracker_combo.value()
+        if (tracker.metarig_mapped and self.processed_xyz_path.exists() and not self.metarig_config_path.exists()):
+            self.generate_metarig_config_btn.setEnabled(True)
+        else:
+            self.generate_metarig_config_btn.setEnabled(False)
+
+        # set availability of Proecssing and slider                
         if self.processed_xyz_path.exists():
             self.process_current_btn.setEnabled(False)
             self.vis_widget.slider.setEnabled(True)
-            
-            # must have xyz params to be able to generate metarig config
-            if self.metarig_config_path.exists():
-                self.generate_metarig_config_btn.setEnabled(False)
-            else:
-                self.generate_metarig_config_btn.setEnabled(True)
                 
         else:
             self.process_current_btn.setEnabled(True)
             self.vis_widget.slider.setEnabled(False)
-            self.generate_metarig_config_btn.setEnabled(False)
 
     def update_slider_position(self):
         # update slider value to stored value if it exists

--- a/pyxy3d/gui/post_processing_widget.py
+++ b/pyxy3d/gui/post_processing_widget.py
@@ -294,11 +294,24 @@ class PostProcessingWidget(QWidget):
     def update_enabled_disabled(self):
 
         # set availability of metarig generation 
-        tracker = self.tracker_combo.value()
+        logger.info("Checking if metarig config can be created...")
+        tracker = self.tracker_combo.currentData().value()
+        logger.info(tracker)
         if (tracker.metarig_mapped and self.processed_xyz_path.exists() and not self.metarig_config_path.exists()):
             self.generate_metarig_config_btn.setEnabled(True)
+            self.generate_metarig_config_btn.setToolTip("Creation of metarig configuration file is now available")
         else:
             self.generate_metarig_config_btn.setEnabled(False)
+        
+        if not tracker.metarig_mapped:
+            self.generate_metarig_config_btn.setToolTip("Tracker is not set up to scale to a metarig")
+        elif self.metarig_config_path.exists():
+            self.generate_metarig_config_btn.setToolTip("The Metarig configuration json file has already been created.Check the tracker subfolder in the recording directory.")
+        elif not self.processed_xyz_path.exists():
+            self.generate_metarig_config_btn.setToolTip("Must process recording to create xyz estimates for metarig configuration")
+        else:
+            self.generate_metarig_config_btn.setToolTip("Click to create a file in the tracker subfolder that can be used to scale a Blender metarig")
+            
 
         # set availability of Proecssing and slider                
         if self.processed_xyz_path.exists():

--- a/pyxy3d/interface.py
+++ b/pyxy3d/interface.py
@@ -53,7 +53,15 @@ class Tracker(ABC):
         Used for file naming creation
         """
         pass
-     
+    @property
+    def metarig_mapped(self):
+        """
+        Defaults to false and can be overriden to True
+        Used to ensure that metarig_config creation is not presented as 
+        an option in GUI
+        """
+        return False
+         
     @property
     def metarig_symmetrical_measures(self):
         """

--- a/pyxy3d/trackers/holistic_opensim_tracker.py
+++ b/pyxy3d/trackers/holistic_opensim_tracker.py
@@ -183,6 +183,10 @@ class HolisticOpenSimTracker(Tracker):
         return "HOLISTIC_OPENSIM"
 
     @property
+    def metarig_mapped(self):
+        return True
+    
+    @property
     def metarig_symmetrical_measures(self):
         return METARIG_SYMMETRICAL_MEASURES
     

--- a/pyxy3d/trackers/holistic_tracker.py
+++ b/pyxy3d/trackers/holistic_tracker.py
@@ -168,7 +168,10 @@ class HolisticTracker(Tracker):
     def name(self):
         return "HOLISTIC"
     
-    
+    @property
+    def metarig_mapped(self):
+        return True
+
     @property
     def metarig_symmetrical_measures(self):
         return METARIG_SYMMETRICAL_MEASURES

--- a/pyxy3d/trackers/holistic_tracker.py
+++ b/pyxy3d/trackers/holistic_tracker.py
@@ -112,42 +112,6 @@ POINT_NAMES = {
     220: "left_pinky_tip",
 }
 
-METARIG_BILATERAL_MEAUSURES = {
-    "Hip_Shoulder_Distance":["hip", "shoulder"],
-    "Shoulder_Inner_Eye_Distance":["inner_eye", "shoulder"],
-    "Palm": ["index_finger_MCP", "pinky_MCP"],
-    "Foot":["heel", "foot_index"],  
-    "Upper_Arm":["shoulder","elbow"],
-    "Forearm":["elbow", "wrist"],
-    "Wrist_to_MCP1":["wrist", "thumb_MCP"],
-    "Wrist_to_MCP2":["wrist", "index_finger_MCP"],
-    "Wrist_to_MCP3":["wrist", "middle_finger_MCP"],
-    "Wrist_to_MCP4":["wrist", "ring_finger_MCP"],
-    "Wrist_to_MCP5":["wrist", "pinky_MCP"],
-    "Prox_Phalanx_1":["thumb_MCP", "thumb_IP"],
-    "Prox_Phalanx_2":["index_finger_MCP", "index_finger_PIP"],
-    "Prox_Phalanx_3":["middle_finger_MCP", "middle_finger_PIP"],
-    "Prox_Phalanx_4":["ring_finger_MCP", "ring_finger_PIP"],
-    "Prox_Phalanx_5":["pinky_MCP", "pinky_PIP"],
-    "Mid_Phalanx_2":["index_finger_PIP", "index_finger_DIP"],
-    "Mid_Phalanx_3":["middle_finger_PIP","middle_finger_DIP"],
-    "Mid_Phalanx_4":["ring_finger_PIP", "ring_finger_DIP"],
-    "Mid_Phalanx_5":["pinky_PIP", "pinky_DIP"],
-    "Dist_Phalanx_1":["thumb_IP", "thumb_tip"],
-    "Dist_Phalanx_2":["index_finger_DIP", "index_finger_tip"],
-    "Dist_Phalanx_3":["middle_finger_DIP","middle_finger_tip"],
-    "Dist_Phalanx_4":["ring_finger_DIP", "middle_finger_tip"],
-    "Dist_Phalanx_5":["pinky_DIP", "pinky_tip"],
-    "Thigh_Length":["hip","knee"],
-    "Shin_Length": ["knee", "ankle"]
-}
-
-
-METARIG_SYMMETRICAL_MEASURES = {
-    "Shoulder_Width":["left_shoulder", "right_shoulder"],
-    "Hip_Width":["left_hip", "right_hip"],
-    "Inner_Eye_Distance":["left_inner_eye", "right_inner_eye"]
-}
 
 # keep ids in distinct ranges to avoid clashes
 POSE_OFFSET = 0
@@ -168,17 +132,6 @@ class HolisticTracker(Tracker):
     def name(self):
         return "HOLISTIC"
     
-    @property
-    def metarig_mapped(self):
-        return True
-
-    @property
-    def metarig_symmetrical_measures(self):
-        return METARIG_SYMMETRICAL_MEASURES
-    
-    @property
-    def metarig_bilateral_measures(self):
-        return METARIG_BILATERAL_MEAUSURES
           
     def run_frame_processor(self, port: int, rotation_count: int):
         # Create a MediaPipe pose instance


### PR DESCRIPTION
Ended up being a little more tricky than I was thinking. Glad this was a distinct issue and PR. Appears to be working well and have now also begun to introduce tool tips. Main updates:

- Generate Metarig Config button on post processing tab
- Tracker API now includes a "metarig_mapped" property (defaults to False) that can be used to assess whether generate button should be enabled
- tooltips included that explain why the button is currently disabled