### PR TITLE
428 fix multicamera to capture volume transition

### DIFF
--- a/dev/demo/demo_gui_main.py
+++ b/dev/demo/demo_gui_main.py
@@ -4,7 +4,7 @@ from pyxy3d import __root__
 from pathlib import Path
 import toml
 from pyxy3d import __app_dir__
-from pyxy3d.gui.main_widget import MainWindow
+from pyxy3d.gui.single_main_widget import MainWindow
 
 app_settings = toml.load(Path(__app_dir__, "settings.toml"))
 recent_projects: list = app_settings["recent_projects"]

--- a/pyxy3d/configurator.py
+++ b/pyxy3d/configurator.py
@@ -196,11 +196,15 @@ class Configurator:
         #     self.dict["point_estimates"] = toml.load(self.point_estimates_toml_path)
         #     self.last_point_estimates_load_time = time()
 
+        if "point_estimates" not in self.dict.keys():
+            self.refresh_point_estimates_from_toml()        
+        
         temp_data = self.dict["point_estimates"].copy()
         for key, value in temp_data.items():
             temp_data[key] = np.array(value)
 
         point_estimates = PointEstimates(**temp_data)
+        
         return point_estimates
     
     def get_charuco(self)-> Charuco:

--- a/pyxy3d/gui/calibrate_capture_volume_widget.py
+++ b/pyxy3d/gui/calibrate_capture_volume_widget.py
@@ -69,7 +69,7 @@ class CalibrateCaptureVolumeWidget(QStackedWidget):
         self.extrinsic_calibration_widget = ExtrinsicCalibrationWidget(self.session)
         self.addWidget(self.extrinsic_calibration_widget)
         self.setCurrentWidget(self.extrinsic_calibration_widget)
-        self.extrinsic_calibration_widget.calibration_complete.connect(self.activate_capture_volume_widget)
+        # self.extrinsic_calibration_widget.calibration_complete.connect(self.activate_capture_volume_widget)
         self.extrinsic_calibration_widget.update_btn_eligibility()
         
         # self.session.unpause_synchronizer()

--- a/pyxy3d/gui/recording_widget.py
+++ b/pyxy3d/gui/recording_widget.py
@@ -225,12 +225,12 @@ class RecordingWidget(QWidget):
          
     @pyqtSlot(dict) 
     def ImageUpdateSlot(self, q_image_dict:dict):
-        logger.info("About to get qpixmap from qimage")
+        logger.debug("About to get qpixmap from qimage")
         for port, thumbnail in q_image_dict.items():
             qpixmap = QPixmap.fromImage(thumbnail)
-            logger.info("About to set qpixmap to display")
+            logger.debug("About to set qpixmap to display")
             self.recording_displays[port].setPixmap(qpixmap)
-            logger.info("successfully set display")
+            logger.debug("successfully set display")
         
 
 class FrameDictionaryEmitter(QThread):

--- a/pyxy3d/gui/single_main_widget.py
+++ b/pyxy3d/gui/single_main_widget.py
@@ -173,6 +173,12 @@ class MainWindow(QMainWindow):
             
         self.setCentralWidget(new_widget)        
 
+    def switch_to_capture_volume(self):
+        """
+        Once the extrinsic calibration is complete, the GUI should automatically switch over to the capture volume widget
+        """
+        self.session.set_mode(SessionMode.CaptureVolumeOrigin) 
+        
     def update_enable_disable(self):
         
         # note: if the cameras are connected,then you can peak
@@ -204,7 +210,7 @@ class MainWindow(QMainWindow):
             self.processing_mode_select.setEnabled(False) 
         
     def disconnect_cameras(self):
-                
+
         self.session.set_mode(SessionMode.Charuco)
         self.session.disconnect_cameras() 
         self.disconnect_cameras_action.setEnabled(False)
@@ -256,7 +262,7 @@ class MainWindow(QMainWindow):
         self.session.qt_signaler.stream_tools_loaded_signal.connect(self.update_enable_disable)
         self.session.qt_signaler.stream_tools_disconnected_signal.connect(self.update_enable_disable)
         self.session.qt_signaler.mode_change_success.connect(self.update_enable_disable)
-
+        self.session.qt_signaler.extrinsic_calibration_complete.connect(self.switch_to_capture_volume)
         
     def add_to_recent_project(self, project_path: str):
         recent_project_action = QAction(project_path, self)

--- a/pyxy3d/session/session.py
+++ b/pyxy3d/session/session.py
@@ -110,7 +110,7 @@ class Session:
         self.monocalibrators = {}
         self.synchronizer.stop_event.set()
         self.synchronizer = None
-
+        self.stream_tools_loaded = False
         self.qt_signaler.stream_tools_disconnected_signal.emit()
 
     def is_camera_setup_eligible(self):

--- a/pyxy3d/session/session.py
+++ b/pyxy3d/session/session.py
@@ -51,6 +51,8 @@ class QtSignaler(QObject):
     unlock_postprocessing = pyqtSignal()
     recording_complete_signal = pyqtSignal()        
     mode_change_success = pyqtSignal()
+    extrinsic_calibration_complete = pyqtSignal()
+
 
     def __init__(self) -> None:
         super(QtSignaler, self).__init__()
@@ -259,6 +261,7 @@ class Session:
                 self.synchronizer.subscribe_to_streams()
 
             case SessionMode.CaptureVolumeOrigin:
+                self.load_estimated_capture_volume()
                 if self.stream_tools_loaded:
                     self.pause_all_monocalibrators()
                     self.synchronizer.unsubscribe_from_streams()
@@ -561,3 +564,5 @@ class Session:
         self.capture_volume.optimize()
 
         self.config.save_capture_volume(self.capture_volume)
+
+        self.qt_signaler.extrinsic_calibration_complete.emit()


### PR DESCRIPTION
Working well now, though issue identified with initial load of pyqtgraph widget. Not sure what is going on or how to resolve this. The whole main window blinks out of existence for a beat, but then returns. This only happens the first time the capture volume or post processing widget is shown (one or the other).