### PR TITLE
561 command line launch project select working

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "pyxy3d"
 version = "0.2.4"
-description = "A package for calibrating standard webcams to enable 3d motion tracking"
+description = "GUI based multicamera calibration that integrates with 2D landmark tracking to triangulate 3D landmark positions"
 authors = ["Mac Prible <prible@gmail.com>"]
 license = "LGPL-3.0-only"
 readme = "README.md"

--- a/pyxy3d/__main__.py
+++ b/pyxy3d/__main__.py
@@ -1,7 +1,3 @@
-import pyxy3d.logger
-
-logger = pyxy3d.logger.get(__name__)
-
 import sys
 import os
 from PySide6.QtWidgets import QApplication
@@ -9,6 +5,10 @@ from pathlib import Path
 
 from pyxy3d.gui.recording_widget import launch_recording_widget
 from pyxy3d.gui.main_widget import launch_main
+import pyxy3d.logger
+
+logger = pyxy3d.logger.get(__name__)
+
 
 def CLI_parser():
     if len(sys.argv) == 1:
@@ -23,4 +23,3 @@ def CLI_parser():
 
         if launch_widget in ["record", "rec", "-r"]:
             launch_recording_widget(session_path)
-

--- a/pyxy3d/gui/workspace_widget.py
+++ b/pyxy3d/gui/workspace_widget.py
@@ -3,7 +3,7 @@ import sys
 import subprocess
 from pathlib import Path
 from PySide6.QtWidgets import QHBoxLayout, QLabel, QWidget, QVBoxLayout, QPushButton, QSpinBox, QGridLayout, QTextBrowser
-from PySide6.QtCore import QFileSystemWatcher, Slot
+from PySide6.QtCore import QFileSystemWatcher, Slot, Qt
 from pyxy3d.controller import Controller
 import pyxy3d.logger
 logger = pyxy3d.logger.get(__name__)
@@ -17,8 +17,8 @@ class WorkspaceSummaryWidget(QWidget):
 
         # self.directory = QLabel(str(self.controller.workspace))
         self.open_workspace_folder_btn = QPushButton("Open Workspace Folder", self)
-
         self.calibrate_btn = QPushButton("Calibrate Capture Volume", self)
+        self.reload_workspace_btn = QPushButton("Reload Workspace")
 
         self.camera_count_spin = QSpinBox()
         self.camera_count_spin.setValue(self.controller.get_camera_count())
@@ -36,14 +36,15 @@ class WorkspaceSummaryWidget(QWidget):
         # Layout
         self.layout = QGridLayout()
         self.setLayout(self.layout)
-        self.layout.addWidget(self.status_HTML,0,0,1,3)
+        self.layout.addWidget(self.status_HTML,0,0,1,4)
 
         camera_spin_layout = QHBoxLayout()
-        camera_spin_layout.addWidget(QLabel("Cameras:"))
-        camera_spin_layout.addWidget(self.camera_count_spin)
+        camera_spin_layout.addWidget(QLabel("Cameras:"), alignment=Qt.AlignmentFlag.AlignRight)
+        camera_spin_layout.addWidget(self.camera_count_spin, alignment=Qt.AlignmentFlag.AlignLeft)
         self.layout.addLayout(camera_spin_layout,1,0,)
-        self.layout.addWidget(self.open_workspace_folder_btn, 1,1)
-        self.layout.addWidget(self.calibrate_btn,1,2)
+        self.layout.addWidget(self.reload_workspace_btn, 1,1)
+        self.layout.addWidget(self.open_workspace_folder_btn, 1,2)
+        self.layout.addWidget(self.calibrate_btn,1,3)
         
     def connect_widgets(self):
         self.open_workspace_folder_btn.clicked.connect(self.open_workspace)  

--- a/pyxy3d/workspace_guide.py
+++ b/pyxy3d/workspace_guide.py
@@ -101,20 +101,26 @@ class WorkspaceGuide:
 
         html = f"""
             <html>
-                <head></head>
+                <head>
+                    <style>
+                        p {{
+                            text-indent: 30px; 
+                        }}
+                    </style>
+                </head>
                 <body>
-                    <h3> Workspace Status </h3>
-                    <p>Directory: {str(self.workspace_dir)}</p>
-                    <p>Camera Count: {self.camera_count}</p>
-                    <h3>Intrinsic Calibration: {self.intrinsic_calibration_status()}</h3>
-                    <p>subdirectory: {str(self.intrinsic_dir)}</p>
-                    <p>missing files:{self.missing_files_in_dir(self.intrinsic_dir)}<p>
-                    <p>cameras needing calibration: {self.uncalibrated_cameras()}
-                    <h3>Extrinsic Calibration: {self.extrinsic_calibration_status()}</h3>
-                    <p>subdirectory: {str(self.extrinsic_dir)}</p>
-                    <p>missing files:{self.missing_files_in_dir(self.extrinsic_dir)}<p>
-                    <h3>Recordings</h3>
-                    <p>valid directories: {self.valid_recording_dir_text()}<p>
+                    <h4>Summary</h4>
+                    <p>    Directory: {str(self.workspace_dir)}</p>
+                    <p>    Camera Count: {self.camera_count}</p>
+                    <h4>Intrinsic Calibration: {self.intrinsic_calibration_status()}</h4>
+                    <p>    subdirectory: {str(self.intrinsic_dir)}</p>
+                    <p>    missing files:{self.missing_files_in_dir(self.intrinsic_dir)}</p>
+                    <p>    cameras needing calibration: {self.uncalibrated_cameras()}</p>
+                    <h4>Extrinsic Calibration: {self.extrinsic_calibration_status()}</h4>
+                    <p>    subdirectory: {str(self.extrinsic_dir)}</p>
+                    <p>    missing files:{self.missing_files_in_dir(self.extrinsic_dir)}</p>
+                    <h4>Recordings</h4>
+                    <p>    valid directories: {self.valid_recording_dir_text()}</p>
                     <p>
                 </body>
             </html> 


### PR DESCRIPTION
Basic project launch working... issue discovered where capture volume widget references appear to get out of sync after reloading the workspace. Consider having the widget load directly from the config and point_estimates toml files as this provides a tighter representation of the actual data stored on the user's system and not just some  variable floating around.