### PR TITLE
minor tweaks for tests to pass

### DIFF
--- a/pyxy3d/configurator.py
+++ b/pyxy3d/configurator.py
@@ -33,6 +33,10 @@ class Configurator:
 
         if exists(self.config_toml_path):
             self.refresh_config_from_toml()
+            # this check only included for interfacing with historical tests...
+            # if underlying tests data updated, this should be removed 
+            if "camera_count" not in self.dict.keys():
+                self.dict["camera_count"] = 0
         else:
             logger.info(
                 "No existing config.toml found; creating starter file with charuco"

--- a/pyxy3d/controller.py
+++ b/pyxy3d/controller.py
@@ -120,9 +120,9 @@ class Controller(QObject):
             self.intrinsic_stream_manager.update_charuco(self.charuco_tracker)
             
     def load_extrinsic_stream_manager(self):
-        logger.info(f"Loading manager for streams saved to {self.extrinsic_dir}")
+        logger.info(f"Loading manager for streams saved to {self.workspace_guide.extrinsic_dir}")
         self.extrinsic_stream_manager = SynchronizedStreamManager(
-            recording_dir=self.extrinsic_dir,
+            recording_dir=self.workspace_guide.extrinsic_dir,
             all_camera_data=self.camera_array.cameras,
             tracker=self.charuco_tracker,
         )
@@ -178,7 +178,7 @@ class Controller(QObject):
         in keeping with project layout
         """
         # copy source over to standard workspace structure
-        target_mp4_path = Path(self.intrinsic_dir, f"port_{port}.mp4")
+        target_mp4_path = Path(self.workspace_guide.intrinsic_dir, f"port_{port}.mp4")
         video_properties = read_video_properties(target_mp4_path)
         size = video_properties["size"]
         new_cam_data = CameraData(

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -99,7 +99,7 @@ def test_video_property_reader():
     assert(source_properties["size"]==(1280,720))
 
 if __name__ == "__main__":
-    test_controller_load_camera_and_stream()
-    # test_extrinsic_calibration()
+    # test_controller_load_camera_and_stream()
+    test_extrinsic_calibration()
     # test_video_property_reader()
 


### PR DESCRIPTION
Some tiny fixes, to allow historical tests to pass that didn't have camera_count configured, and updating controller so that directory references are all managed by workspace_guide