### PR TITLE
Grid history getting reinitialized when charuco is updated

### DIFF
--- a/pyxy3d/controller.py
+++ b/pyxy3d/controller.py
@@ -116,8 +116,11 @@ class Controller(QObject):
         self.config.save_charuco(self.charuco)
         self.charuco_tracker = CharucoTracker(self.charuco)
 
+
         if hasattr(self, "intrinsic_stream_manager"):
+            logger.info("Updating charuco within the intrinsic stream manager")
             self.intrinsic_stream_manager.update_charuco(self.charuco_tracker)
+
             
     def load_extrinsic_stream_manager(self):
         logger.info(f"Loading manager for streams saved to {self.workspace_guide.extrinsic_dir}")

--- a/pyxy3d/intrinsic_stream_manager.py
+++ b/pyxy3d/intrinsic_stream_manager.py
@@ -82,7 +82,9 @@ class IntrinsicStreamManager:
     def update_charuco(self,charuco_tracker:CharucoTracker):
         for stream in self.streams.values():
             stream.tracker = charuco_tracker
-            
+        
+        for emitter in self.frame_emitters.values():
+            emitter.initialize_grid_capture_history()
      
     def play_stream(self,port):
         logger.info(f"Begin playing stream at port {port}")


### PR DESCRIPTION
Changes made within the stream manager to update frame emitter when charuco is updated.