### PR TITLE
573 reloading the workspace freezes gui

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyxy3d"
-version = "0.3.2"
+version = "0.3.3"
 description = "GUI based multicamera calibration that integrates with 2D landmark tracking to triangulate 3D landmark positions"
 authors = ["Mac Prible <prible@gmail.com>"]
 license = "LGPL-3.0-only"

--- a/pyxy3d/configurator.py
+++ b/pyxy3d/configurator.py
@@ -51,8 +51,8 @@ class Configurator:
             charuco = Charuco(4, 5, 11, 8.5, square_size_overide_cm=5.4)
             self.save_charuco(charuco)
 
-        if exists(self.point_estimates_toml_path):
-            self.refresh_point_estimates_from_toml()
+        # if exists(self.point_estimates_toml_path):
+            # self.refresh_point_estimates_from_toml()
 
     def save_camera_count(self, count):
         self.camera_count = count
@@ -177,9 +177,6 @@ class Configurator:
 
     def get_point_estimates(self) -> PointEstimates:
         # only load point estimates into dictionary if saved more recently than last loaded
-        # if self.last_point_estimates_save_time > self.last_point_estimates_load_time:
-        #     self.dict["point_estimates"] = toml.load(self.point_estimates_toml_path)
-        #     self.last_point_estimates_load_time = time()
 
         if "point_estimates" not in self.dict.keys():
             self.refresh_point_estimates_from_toml()


### PR DESCRIPTION
loading of controller data structures pushed into a qthread that signals the GUI to rebuild when it finishes. 

Had to make sure that point_estimates only load when specifically called for (not on config init) because that was what was slowing things down. 

Consider use of rtoml to reduce time required for point_estimates to load, which is the key laggy component I can currently identify...