### PR TITLE
584 extract calibration points from video automatically

### DIFF
--- a/pyxy3d/calibration/intrinsic_calibrator.py
+++ b/pyxy3d/calibration/intrinsic_calibrator.py
@@ -28,18 +28,25 @@ class IntrinsicCalibrator:
 
         self.frame_packet_q = Queue()
         self.stream.subscribe(self.frame_packet_q)
-        self.harvest_frames()
 
+        # The following group of parameters relate to the autopopulation of the calibrator
+        self.grid_history_q = Queue()  # for passing ids, img_loc used in calibration 
+        self.auto_store_data = Event()
+        self.auto_store_data.clear()
+        self.auto_pop_frame_wait = 0  # how many frames will you hold ofF checking if the board can be added to the calibration pile.
+
+        self.harvest_frames()
+         
     def harvest_frames(self):
         self.stop_event = Event()
         self.stop_event.clear()
-
+        
         def harvest_worker():
             while True:
                 frame_packet = self.frame_packet_q.get()
                 if self.stop_event.is_set():
-                    
                     break
+
                 self.add_frame_packet(frame_packet)
 
             logger.info(f"Harvest frames successfully ended in calibrator for port {self.stream.port}")
@@ -49,12 +56,8 @@ class IntrinsicCalibrator:
     def stop(self):
         logger.info("Beginning to stop intrinsic calibrator")
         self.stop_event.set()
-    
         self.stream.unsubscribe(self.frame_packet_q)
-        
         self.frame_packet_q.put(-1)
-        # logger.info(f"Waiting for harvest thread to stop at port {self.port}")
-        # self.harvest_thread.join()
 
     @property
     def grid_count(self):
@@ -91,21 +94,62 @@ class IntrinsicCalibrator:
             self.all_obj_loc[index] = frame_packet.points.obj_loc
 
             self.active_frame_index = index
+        
+            if self.auto_store_data.is_set():
+                point_id = frame_packet.points.point_id
+                
+                if point_id.size == 0:
+                    corner_count = 0
+                else:
+                    corner_count = frame_packet.points.point_id.shape[0]
+                logger.info(f"Corner count is {corner_count} and frame wait is {self.auto_pop_frame_wait}")
+                if self.auto_pop_frame_wait == 0 and corner_count > self.threshold_corner_count:
+                    # add frame to calibration data and reset the wait time
+                    self.add_calibration_frame_indices(index)
+                    self.auto_pop_frame_wait = self.wait_between 
+                else:
+                    # count down to the next frame to consider autopopulating
+                    self.auto_pop_frame_wait = max(self.auto_pop_frame_wait-1,0)       
+                
+        else:  # end of stream, so stop auto pop
+            self.auto_store_data.clear()    
 
     def add_calibration_frame_indices(self, frame_index: int):
+        """
+        A "side effect" of this method is that the corner id and img_loc
+        data is placed on a q. This q is consumed by the frame_emitter
+        which will update the grid capture history based with those grids
+
+        This allows the GUI element (frame emitter) to stay in sync with the 
+        calibrator. 
+        """
+        logger.info(f"Adding frame data to calibration inputs for frame index {frame_index}")
         self.calibration_frame_indices.append(frame_index)
+        
+        # Backchannel communication to frame_emitter to keep things aligned
+        ids = self.all_ids[frame_index]
+        img_loc = self.all_img_loc[frame_index]
+        self.grid_history_q.put((ids,img_loc))
+        
 
     def clear_calibration_data(self):
+        logger.info("Clearing calibration data..")
         self.calibration_frame_indices = []
         self.set_calibration_inputs()
         
-        
+    def initiate_auto_pop(self, wait_between,threshold_corner_count):
+        logger.info(f"Initiating autopopulation of corner data in port {self.camera.port}")
+        self.clear_calibration_data()
+        self.wait_between = wait_between
+        self.threshold_corner_count = threshold_corner_count        
+        self.auto_store_data.set()
+        self.initialize_point_history()
 
     def set_calibration_inputs(self):
         self.calibration_point_ids = []
         self.calibration_img_loc = []
         self.calibration_obj_loc = []
-
+        logger.info(f"Blank calibration inputs initialized at port {self.camera.port }")
         for index in self.calibration_frame_indices:
             id_count = len(self.all_ids[index])
             if id_count > 3:  # I believe this is a requirement of opencv
@@ -114,7 +158,7 @@ class IntrinsicCalibrator:
                 self.calibration_obj_loc.append(self.all_obj_loc[index])
             else:
                 logger.info(f"Note that empty data stored in frame index {index}. This is not being used in the calibration")
-
+        logger.info(f"Total size of inputs is {len(self.calibration_point_ids)}")
 
     def calibrate_camera(self):
         """

--- a/pyxy3d/calibration/intrinsic_calibrator.py
+++ b/pyxy3d/calibration/intrinsic_calibrator.py
@@ -106,7 +106,7 @@ class IntrinsicCalibrator:
                 else:
                     corner_count = frame_packet.points.point_id.shape[0]
                 logger.debug(f"Corner count is {corner_count} and frame wait is {self.auto_pop_frame_wait}")
-                if self.auto_pop_frame_wait == 0 and corner_count > self.threshold_corner_count:
+                if self.auto_pop_frame_wait == 0 and corner_count >= self.threshold_corner_count:
                     # add frame to calibration data and reset the wait time
                     self.add_calibration_frame_index(index)
                     self.auto_pop_frame_wait = self.wait_between 
@@ -129,7 +129,7 @@ class IntrinsicCalibrator:
         new_potential_frames = []
         for frame_index, ids in self.all_ids.items():
             if frame_index not in self.calibration_frame_indices:
-                if len(ids) > 3: # just a quick check for minimal data in the frame
+                if len(ids) > 6: # believe this may be a requirement of the calibration algorithm
                     new_potential_frames.append(frame_index)
             
         sample_size = self.target_grid_count-actual_grid_count
@@ -175,8 +175,8 @@ class IntrinsicCalibrator:
         self.wait_between = wait_between
         self.threshold_corner_count = threshold_corner_count        
         self.target_grid_count = target_grid_count
-        self.auto_store_data.set()
         self.initialize_point_history()
+        self.auto_store_data.set()
 
     def set_calibration_inputs(self):
         """

--- a/pyxy3d/cameras/camera_array.py
+++ b/pyxy3d/cameras/camera_array.py
@@ -118,6 +118,15 @@ class CameraData:
 
         return camera_display_dict
 
+
+    def erase_calibration_data(self):
+        self.error = None
+        self.matrix = None
+        self.distortions = None
+        self.grid_count = None
+        self.translation = None
+        self.rotation = None
+        
 @dataclass
 class CameraArray:
     """The plan is that this will expand to become an interface for setting the origin.

--- a/pyxy3d/controller.py
+++ b/pyxy3d/controller.py
@@ -251,7 +251,7 @@ class Controller(QObject):
             self.intrinsic_stream_manager.calibrate_camera(port)
             
             # safety assignment here as references seem to be getting disjointed.
-            self.camera_array.cameras[port] = self.intrinsic_stream_manager.cameras[port]
+            # self.camera_array.cameras[port] = self.intrinsic_stream_manager.cameras[port]
             camera_data = self.camera_array.cameras[port]
             self.config.save_camera(camera_data)
             self.push_camera_data(port)

--- a/pyxy3d/controller.py
+++ b/pyxy3d/controller.py
@@ -21,7 +21,10 @@ from pyxy3d.calibration.capture_volume.quality_controller import QualityControll
 from pyxy3d.calibration.capture_volume.helper_functions.get_point_estimates import (
     get_point_estimates,
 )
-from pyxy3d.synchronized_stream_manager import SynchronizedStreamManager, read_video_properties
+from pyxy3d.synchronized_stream_manager import (
+    SynchronizedStreamManager,
+    read_video_properties,
+)
 from pyxy3d.workspace_guide import WorkspaceGuide
 from collections import OrderedDict
 
@@ -31,6 +34,7 @@ logger = pyxy3d.logger.get(__name__)
 
 
 FILTERED_FRACTION = 0.025  # by default, 2.5% of image points with highest reprojection error are filtered out during calibration
+
 
 class CalibrationStage(Enum):
     NO_INTRINSIC_VIDEO = auto()
@@ -49,6 +53,7 @@ class Controller(QObject):
     new_camera_data = Signal(int, OrderedDict)  # port, camera_display_dictionary
     capture_volume_calibrated = Signal()
     capture_volume_shifted = Signal()
+    enable_inputs = Signal(int, bool)  # port, enable
     post_processing_complete = Signal()
 
     def __init__(self, workspace_dir: Path):
@@ -65,7 +70,7 @@ class Controller(QObject):
         # self.camera_count = self.config.get_camera_count()  # reference to ensure that files are in place to meet user intent
 
         logger.info("Building workpace guide")
-        self.workspace_guide = WorkspaceGuide(self.workspace,self.camera_count)
+        self.workspace_guide = WorkspaceGuide(self.workspace, self.camera_count)
         self.workspace_guide.intrinsic_dir.mkdir(exist_ok=True, parents=True)
         self.workspace_guide.extrinsic_dir.mkdir(exist_ok=True, parents=True)
         self.workspace_guide.recording_dir.mkdir(exist_ok=True, parents=True)
@@ -73,9 +78,10 @@ class Controller(QObject):
         self.capture_volume = None
         # needs to exist before main widget can connect to its finished signal
         self.load_workspace_thread = QThread()
+        self.calibrate_camera_threads = {}
+        self.autocalibrate_threads = {}
         
     def load_workspace(self):
-        
         def worker():
             logger.info("Assess whether to load cameras")
             if self.workspace_guide.all_instrinsic_mp4s_available():
@@ -83,8 +89,8 @@ class Controller(QObject):
                 self.load_intrinsic_stream_manager()
                 self.cameras_loaded = True
             else:
-                self.cameras_loaded = False 
-           
+                self.cameras_loaded = False
+
             logger.info("Assess whether to load capture volume")
             if self.camera_array.all_extrinsics_calibrated():
                 self.load_estimated_capture_volume()
@@ -92,45 +98,42 @@ class Controller(QObject):
             else:
                 self.capture_volume_loaded = False
 
-             
         self.load_workspace_thread.run = worker
         self.load_workspace_thread.start()
 
-    def set_camera_count(self, count:int):
+    def set_camera_count(self, count: int):
         self.camera_count = count
         self.config.save_camera_count(count)
-    
-    def get_camera_count(self)->int:
+
+    def get_camera_count(self) -> int:
         count = self.config.get_camera_count()
         self.camera_count = count
         return count
 
-    
-    def all_instrinsic_mp4s_available(self)->bool:
+    def all_instrinsic_mp4s_available(self) -> bool:
         return self.workspace_guide.all_instrinsic_mp4s_available()
-   
-    def all_extrinsic_mp4s_available(self)->bool:
+
+    def all_extrinsic_mp4s_available(self) -> bool:
         return self.workspace_guide.all_extrinsic_mp4s_available()
 
-
-    def all_intrinsics_estimated(self)->bool:
+    def all_intrinsics_estimated(self) -> bool:
         """
         At this point, processing extrinsics and calibrating capture volume should be allowed
         """
         return self.camera_array.all_intrinsics_calibrated()
-    
-    def all_extrinsics_estimated(self)->bool:
+
+    def all_extrinsics_estimated(self) -> bool:
         """
         At this point, the capture volume tab should be available
         """
-        cameras_good =  self.camera_array.all_extrinsics_calibrated()
+        cameras_good = self.camera_array.all_extrinsics_calibrated()
         point_estimates_good = self.config.point_estimates_toml_path.exists()
         all_data_available = self.workspace_guide.all_extrinsic_mp4s_available()
         return cameras_good and point_estimates_good and all_data_available
-         
-    def recordings_available(self)->bool:
+
+    def recordings_available(self) -> bool:
         return len(self.workspace_guide.valid_recording_dirs()) > 0
-         
+
     def get_charuco_params(self) -> dict:
         return self.config.dict["charuco"]
 
@@ -139,14 +142,14 @@ class Controller(QObject):
         self.config.save_charuco(self.charuco)
         self.charuco_tracker = CharucoTracker(self.charuco)
 
-
         if hasattr(self, "intrinsic_stream_manager"):
             logger.info("Updating charuco within the intrinsic stream manager")
             self.intrinsic_stream_manager.update_charuco(self.charuco_tracker)
 
-            
     def load_extrinsic_stream_manager(self):
-        logger.info(f"Loading manager for streams saved to {self.workspace_guide.extrinsic_dir}")
+        logger.info(
+            f"Loading manager for streams saved to {self.workspace_guide.extrinsic_dir}"
+        )
         self.extrinsic_stream_manager = SynchronizedStreamManager(
             recording_dir=self.workspace_guide.extrinsic_dir,
             all_camera_data=self.camera_array.cameras,
@@ -155,20 +158,23 @@ class Controller(QObject):
 
     def process_extrinsic_streams(self, fps_target=None):
         def worker():
-            output_path = Path(self.workspace_guide.extrinsic_dir, "CHARUCO", "xy_CHARUCO.csv")
-            output_path.unlink() # make sure this doesn't exist to begin with.
+            output_path = Path(
+                self.workspace_guide.extrinsic_dir, "CHARUCO", "xy_CHARUCO.csv"
+            )
+            output_path.unlink()  # make sure this doesn't exist to begin with.
 
             self.load_extrinsic_stream_manager()
             self.extrinsic_stream_manager.process_streams(fps_target=fps_target)
 
-            logger.info(f"Processing of extrinsic calibration begun...waiting for output to populate: {output_path}")
+            logger.info(
+                f"Processing of extrinsic calibration begun...waiting for output to populate: {output_path}"
+            )
             while not output_path.exists():
                 sleep(0.5)
                 logger.info(
                     f"Waiting for 2D tracked points to populate at {output_path}"
                 )
 
-        
     def load_intrinsic_stream_manager(self):
         self.intrinsic_stream_manager = IntrinsicStreamManager(
             recording_dir=self.workspace_guide.intrinsic_dir,
@@ -176,7 +182,7 @@ class Controller(QObject):
             tracker=self.charuco_tracker,
         )
         logger.info("Intrinsic stream manager has loaded")
-        
+
         # signal to main GUI that the Camera tab needs to be reloaded
         # self.intrinsicStreamsLoaded.emit()
 
@@ -189,7 +195,9 @@ class Controller(QObject):
         self.camera_array = CameraArray(preconfigured_cameras)
 
         # double check that no new camera associated files have been placed in the intrinsic calibration folder
-        all_ports = self.workspace_guide.get_ports_in_dir(self.workspace_guide.intrinsic_dir)
+        all_ports = self.workspace_guide.get_ports_in_dir(
+            self.workspace_guide.intrinsic_dir
+        )
 
         for port in all_ports:
             if port not in self.camera_array.cameras:
@@ -211,7 +219,6 @@ class Controller(QObject):
         )
         self.camera_array.cameras[port] = new_cam_data
         self.config.save_camera_array(self.camera_array)
-    
 
     def get_intrinsic_stream_frame_count(self, port):
         return self.intrinsic_stream_manager.get_frame_count(port)
@@ -246,19 +253,22 @@ class Controller(QObject):
 
     def calibrate_camera(self, port):
         def worker():
-            # self.intrinsic_stream_manager.pause_stream(port)
-            logger.info(f"Calibrating camera at port {port}")
-            self.intrinsic_stream_manager.calibrate_camera(port)
-            
-            # safety assignment here as references seem to be getting disjointed.
-            # self.camera_array.cameras[port] = self.intrinsic_stream_manager.cameras[port]
-            camera_data = self.camera_array.cameras[port]
-            self.config.save_camera(camera_data)
-            self.push_camera_data(port)
-        
-        self.calibrateCameraThread = QThread()
-        self.calibrateCameraThread.run = worker
-        self.calibrateCameraThread.start()
+            if self.intrinsic_stream_manager.calibrators[port].grid_count > 0:
+                self.enable_inputs.emit(port, False) 
+                self.camera_array.cameras[port].erase_calibration_data()
+                logger.info(f"Calibrating camera at port {port}")
+                self.intrinsic_stream_manager.calibrate_camera(port)
+
+                camera_data = self.camera_array.cameras[port]
+                self.config.save_camera(camera_data)
+                self.push_camera_data(port)
+                self.enable_inputs.emit(port, True) 
+            else:
+                logger.warn("Not enough grids available to calibrate")
+
+        self.calibrate_camera_threads[port] = QThread()
+        self.calibrate_camera_threads[port].run = worker
+        self.calibrate_camera_threads[port].start()
 
     def push_camera_data(self, port):
         logger.info(f"Pushing camera data for port {port}")
@@ -271,7 +281,6 @@ class Controller(QObject):
         self.intrinsic_stream_manager.apply_distortion(camera, undistort)
 
     def rotate_camera(self, port, change):
-
         camera_data = self.camera_array.cameras[port]
         count = camera_data.rotation_count
         count += change
@@ -282,8 +291,10 @@ class Controller(QObject):
             camera_data.rotation_count = count
 
         # note that extrinsic streams not altered.... just reload an replay
-        self.intrinsic_stream_manager.set_stream_rotation(port,camera_data.rotation_count)
-        
+        self.intrinsic_stream_manager.set_stream_rotation(
+            port, camera_data.rotation_count
+        )
+
         self.push_camera_data(port)
         self.config.save_camera(camera_data)
 
@@ -320,20 +331,26 @@ class Controller(QObject):
         """
 
         def worker():
-            output_path = Path(self.workspace_guide.extrinsic_dir, "CHARUCO", "xy_CHARUCO.csv")
+            output_path = Path(
+                self.workspace_guide.extrinsic_dir, "CHARUCO", "xy_CHARUCO.csv"
+            )
             if output_path.exists():
-                output_path.unlink() # make sure this doesn't exist to begin with.
+                output_path.unlink()  # make sure this doesn't exist to begin with.
 
             self.load_extrinsic_stream_manager()
             self.extrinsic_stream_manager.process_streams(fps_target=100)
 
-            logger.info(f"Processing of extrinsic calibration begun...waiting for output to populate: {output_path}")
+            logger.info(
+                f"Processing of extrinsic calibration begun...waiting for output to populate: {output_path}"
+            )
 
             while not output_path.exists():
-                sleep(.5)
+                sleep(0.5)
                 # moderate the frequency with which logging statements get made
-                if round(time())%3==0:
-                    logger.info( f"Waiting for 2D tracked points to populate at {output_path}")
+                if round(time()) % 3 == 0:
+                    logger.info(
+                        f"Waiting for 2D tracked points to populate at {output_path}"
+                    )
 
             # note that this processing will wait until it is complete
             self.process_extrinsic_streams(fps_target=100)
@@ -380,15 +397,18 @@ class Controller(QObject):
         )
         self.calibrate_capture_volume_thread.start()
 
-    def process_recordings(self, recording_path:Path, tracker_enum:TrackerEnum):
+    def process_recordings(self, recording_path: Path, tracker_enum: TrackerEnum):
         """
         Initiates worker thread to begin post processing.
         TrackerEnum passed in so that access is given to both the tracker and the name because the name is needed for file/folder naming
         """
+
         def worker():
             logger.info(f"Beginning to process video files at {recording_path}")
             logger.info(f"Creating post processor for {recording_path}")
-            self.post_processor = PostProcessor(self.camera_array, recording_path, tracker_enum)
+            self.post_processor = PostProcessor(
+                self.camera_array, recording_path, tracker_enum
+            )
             self.post_processor.create_xy()
             self.post_processor.create_xyz()
 
@@ -397,8 +417,7 @@ class Controller(QObject):
         self.process_recordings_thread.finished.connect(self.post_processing_complete)
         self.process_recordings_thread.start()
 
-        
-    def rotate_capture_volume(self,direction:str):
+    def rotate_capture_volume(self, direction: str):
         transformations = {
             "x+": np.array(
                 [[1, 0, 0, 0], [0, 0, 1, 0], [0, -1, 0, 0], [0, 0, 0, 1]], dtype=float
@@ -422,24 +441,47 @@ class Controller(QObject):
 
         self.capture_volume.shift_origin(transformations[direction])
         self.capture_volume_shifted.emit()
+
         # don't hold up the rest of the processing just to save the capture volume
         def worker():
             self.config.save_capture_volume(self.capture_volume)
-        
+
         self.rotate_capture_volume_thread = QThread()
         self.rotate_capture_volume_thread.run = worker
         self.rotate_capture_volume_thread.start()
-        
 
     def set_capture_volume_origin_to_board(self, origin_index):
-        self.capture_volume.set_origin_to_board(
-            origin_index, self.charuco
-        )
+        self.capture_volume.set_origin_to_board(origin_index, self.charuco)
         self.capture_volume_shifted.emit()
+
         def worker():
             self.config.save_capture_volume(self.capture_volume)
 
         self.set_origin_thread = QThread()
         self.set_origin_thread.run = worker
         self.set_origin_thread.start()
-        
+
+    def autocalibrate(self, port, grid_count, board_threshold):
+        def worker():
+            self.enable_inputs.emit(port, False) 
+            self.camera_array.cameras[port].erase_calibration_data()
+            self.config.save_camera(self.camera_array.cameras[port])
+            self.push_camera_data(port)
+            logger.info(f"Initiate autocalibration of grids for port {port}")
+            self.intrinsic_stream_manager.autocalibrate(
+                port, grid_count, board_threshold
+            )
+
+            while self.camera_array.cameras[port].matrix is None:
+                logger.info(f"Waiting for calibration to complete at port {port}")
+                sleep(2)
+            
+            self.config.save_camera(self.camera_array.cameras[port])
+            self.push_camera_data(port)
+            self.intrinsic_stream_manager.stream_jump_to(port, 0)
+            self.enable_inputs.emit(port, True) 
+
+        self.autocalibrate_threads[port] = QThread()
+        self.autocalibrate_threads[port].run = worker
+        self.autocalibrate_threads[port].start()
+            

--- a/pyxy3d/gui/camera_management/playback_widget.py
+++ b/pyxy3d/gui/camera_management/playback_widget.py
@@ -185,6 +185,7 @@ class IntrinsicCalibrationWidget(QWidget):
         self.scaling_spin.valueChanged.connect(self.on_scale_change)
         self.controller.intrinsic_stream_manager.frame_emitters[self.port].ImageBroadcast.connect(self.update_image)
         self.controller.intrinsic_stream_manager.frame_emitters[self.port].FrameIndexBroadcast.connect(self.update_index)
+        self.controller.enable_inputs.connect(self.update_enable_all_inputs)
 
         # initialize stream to push first frame to widget then hold
         # must be done after signals and slots connected for effect to take hold
@@ -193,6 +194,7 @@ class IntrinsicCalibrationWidget(QWidget):
         # self.play_started = True
         self.controller.pause_intrinsic_stream(self.port)
         self.controller.stream_jump_to(self.port, 0)
+
 
     def play_video(self):
         # if self.play_started:
@@ -286,10 +288,28 @@ class IntrinsicCalibrationWidget(QWidget):
         self.controller.stream_jump_to(self.port, self.index)
 
 
+    def update_enable_all_inputs(self, port, enable:bool):
+        # Control widget accessibilty from controller signal to all ports
+        if port == self.port:
+            self.play_button.setEnabled(enable)
+            self.slider.setEnabled(enable)
+            self.add_grid_btn.setEnabled(enable)
+            self.calibrate_btn.setEnabled(enable)
+            self.camera_data_display.setEnabled(enable)
+            self.clear_calibration_data_btn.setEnabled(enable)
+            self.toggle_distortion.setEnabled(enable)
+            self.cw_rotation_btn.setEnabled(enable)
+            self.ccw_rotation_btn.setEnabled(enable)
+            self.autocalibrate_btn.setEnabled(enable)
+            self.target_grid_count_spin.setEnabled(enable)
+            self.board_threshold_spin.setEnabled(enable)
+            self.scaling_spin.setEnabled(enable)
+        
     def autocalibrate(self):
         grid_count = self.target_grid_count_spin.value()
         board_threshold = self.board_threshold_spin.value()
-        self.controller.intrinsic_stream_manager.autopopulate_grids(self.port,grid_count, board_threshold)
+        self.update_enable_all_inputs(self.port, False)
+        self.controller.autocalibrate(self.port,grid_count, board_threshold)
         
 if __name__ == "__main__":
     app = QApplication(sys.argv)

--- a/pyxy3d/gui/camera_management/playback_widget.py
+++ b/pyxy3d/gui/camera_management/playback_widget.py
@@ -103,6 +103,7 @@ class IntrinsicCalibrationWidget(QWidget):
         self.ccw_rotation_btn = QPushButton(QIcon(str(CAM_ROTATE_LEFT_PATH)), "")
         self.ccw_rotation_btn.setMaximumSize(35, 35)
 
+        self.autopopulate_grids_btn = QPushButton("Autopopulate Grids")
 
         # Create the spinbox
         self.spin_box_label = QLabel("Undistorted Image Scale")
@@ -150,6 +151,8 @@ class IntrinsicCalibrationWidget(QWidget):
         self.right_panel.addLayout(self.distortion_control_span)
         self.layout.addLayout(self.right_panel)
 
+        self.right_panel.addWidget(self.autopopulate_grids_btn)
+
     def connect_widgets(self):
         self.play_button.clicked.connect(self.play_video)
         self.slider.sliderMoved.connect(self.slider_moved)
@@ -160,9 +163,9 @@ class IntrinsicCalibrationWidget(QWidget):
         self.toggle_distortion.stateChanged.connect(self.toggle_distortion_changed)
         self.ccw_rotation_btn.clicked.connect(self.rotate_ccw)
         self.cw_rotation_btn.clicked.connect(self.rotate_cw)
+        self.autopopulate_grids_btn.clicked.connect(self.autopopulate_grids) 
        
         self.scaling_spinBox.valueChanged.connect(self.on_scale_change)
-        
         self.controller.intrinsic_stream_manager.frame_emitters[self.port].ImageBroadcast.connect(self.update_image)
         self.controller.intrinsic_stream_manager.frame_emitters[self.port].FrameIndexBroadcast.connect(self.update_index)
 
@@ -217,7 +220,7 @@ class IntrinsicCalibrationWidget(QWidget):
                     self.play_button.setIcon(self.play_icon)
 
     def update_image(self, port, pixmap):
-        logger.info(f"Running `update_image` in playback widget for port {self.port}")
+        logger.debug(f"Running `update_image` in playback widget for port {self.port}")
         if port == self.port:
             self.frame_image.setPixmap(pixmap)
 
@@ -265,6 +268,12 @@ class IntrinsicCalibrationWidget(QWidget):
         self.controller.rotate_camera(self.port, -1)
         self.controller.stream_jump_to(self.port, self.index)
 
+
+    def autopopulate_grids(self):
+        grid_count = 40
+        board_threshold = .7
+        self.controller.intrinsic_stream_manager.autopopulate_grids(self.port,grid_count, board_threshold)
+        
 if __name__ == "__main__":
     app = QApplication(sys.argv)
     from pyxy3d import __root__

--- a/pyxy3d/gui/frame_emitters/playback_frame_emitter.py
+++ b/pyxy3d/gui/frame_emitters/playback_frame_emitter.py
@@ -191,9 +191,9 @@ class PlaybackFrameEmitter(QThread):
         This grid history is likely best tracked by the controller and
         a reference should be past to the frame emitter
         """
-        logger.info("Attempting to add to grid history")
+        # logger.info("Attempting to add to grid history")
         if len(ids) > 3:
-            logger.info("enough points to add")
+            # logger.info("enough points to add")
             self.grid_capture_history = draw_charuco.grid_history(
                 self.grid_capture_history,
                 ids,

--- a/pyxy3d/gui/main_widget.py
+++ b/pyxy3d/gui/main_widget.py
@@ -199,14 +199,6 @@ class MainWindow(QMainWindow):
         self.controller.load_workspace()
         self.controller.load_workspace_thread.finished.connect(self.build_central_tabs)
         
-        # if hasattr(self.controller, "intrinsic_stream_manager"):
-            # logger.info("Attempting to wind down currently existing stream tools")
-            # self.controller.intrinsic_stream_manager.close_stream_tools()
-
-        # Rebuild the central tabs
-        # logger.info("Building Central tabs")
-        # self.build_central_tabs()
-
 
     def add_to_recent_project(self, project_path: str):
         recent_project_action = QAction(project_path, self)

--- a/pyxy3d/intrinsic_stream_manager.py
+++ b/pyxy3d/intrinsic_stream_manager.py
@@ -134,25 +134,26 @@ class IntrinsicStreamManager:
 
         board_corners = self.tracker.charuco.board.getChessboardCorners()
         total_corner_count = board_corners.shape[0]
-        threshold_corner_count = (total_corner_count*pct_board_threshold)
-        
-        logger.info(f"Corners for charuco are {board_corners}") 
+        threshold_corner_count = total_corner_count * pct_board_threshold
 
+        logger.info(f"Corners for charuco are {board_corners}")
+
+        # calculate basic wait time between board collections 
+        # if many frames have incomplete data, this will fail to reach the target board count
         start_frame_index = stream.start_frame_index
         last_frame_index = stream.last_frame_index
-
         total_frames = last_frame_index - start_frame_index + 1
         wait_between = int(total_frames / grid_count)
 
-        last_grid_index = -wait_between
-        original_fps = stream.fps
         stream.set_fps_target(100)  # speed through the stream
 
         # jump to first frame, play videos and cycle quickly through frames
         stream.jump_to(0)
         frame_emitter.initialize_grid_capture_history()
         intrinsic_calibrator.initiate_auto_pop(
-            wait_between=wait_between, threshold_corner_count=threshold_corner_count
+            wait_between=wait_between,
+            threshold_corner_count=threshold_corner_count,
+            target_grid_count=grid_count,
         )
 
         stream.unpause()

--- a/pyxy3d/intrinsic_stream_manager.py
+++ b/pyxy3d/intrinsic_stream_manager.py
@@ -109,7 +109,7 @@ class IntrinsicStreamManager:
         self.unpause_stream(port)
 
     def add_calibration_grid(self, port: int, frame_index: int):
-        self.calibrators[port].add_calibration_frame_indices(frame_index)
+        self.calibrators[port].add_calibration_frame_index(frame_index)
 
     def clear_calibration_data(self, port: int):
         self.calibrators[port].clear_calibration_data()
@@ -135,6 +135,7 @@ class IntrinsicStreamManager:
         board_corners = self.tracker.charuco.board.getChessboardCorners()
         total_corner_count = board_corners.shape[0]
         threshold_corner_count = total_corner_count * pct_board_threshold
+        threshold_corner_count = max(threshold_corner_count,6)   # additional requirement that I believe is part of the alogrithm
 
         logger.info(f"Corners for charuco are {board_corners}")
 

--- a/pyxy3d/intrinsic_stream_manager.py
+++ b/pyxy3d/intrinsic_stream_manager.py
@@ -1,5 +1,5 @@
 import pyxy3d.logger
-
+from time import sleep
 import cv2
 from pathlib import Path
 from pyxy3d.interface import FramePacket
@@ -127,7 +127,7 @@ class IntrinsicStreamManager:
     def set_stream_rotation(self, port, rotation_count):
         self.streams[port].rotation_count = rotation_count
 
-    def autopopulate_grids(self, port, grid_count, pct_board_threshold):
+    def autocalibrate(self, port, grid_count, pct_board_threshold):
         stream = self.streams[port]
         intrinsic_calibrator = self.calibrators[port]
         frame_emitter = self.frame_emitters[port]
@@ -158,3 +158,9 @@ class IntrinsicStreamManager:
         )
 
         stream.unpause()
+
+        while intrinsic_calibrator.grid_count < grid_count:
+            logger.info(f"Waiting for sufficient calibration boards to become populated at port {port}")
+            sleep(2)
+        
+        intrinsic_calibrator.calibrate_camera()

--- a/tests/test_intrinsic_calibrator.py
+++ b/tests/test_intrinsic_calibrator.py
@@ -1,5 +1,7 @@
 from pathlib import Path
+import random    
 from queue import Queue
+from time import sleep
 import numpy as np
 from pyxy3d import __root__
 from pyxy3d.helper import copy_contents
@@ -12,13 +14,15 @@ import pyxy3d.logger
 from pyxy3d.calibration.intrinsic_calibrator import IntrinsicCalibrator
 
 logger = pyxy3d.logger.get(__name__)
-def test_intrinsic_calibrator():
-    
-    # use a general video file with a charuco for convenience
-    original_data_path= Path(__root__, "tests", "sessions", "4_cam_recording")
-    destination_path =Path(__root__, "tests", "sessions_copy_delete", "4_cam_recording")
-    copy_contents(original_data_path,destination_path)
 
+
+def test_intrinsic_calibrator():
+    # use a general video file with a charuco for convenience
+    original_data_path = Path(__root__, "tests", "sessions", "4_cam_recording")
+    destination_path = Path(
+        __root__, "tests", "sessions_copy_delete", "4_cam_recording"
+    )
+    copy_contents(original_data_path, destination_path)
 
     recording_directory = Path(
         __root__, "tests", "sessions", "post_monocal", "calibration", "extrinsic"
@@ -29,38 +33,40 @@ def test_intrinsic_calibrator():
     )
 
     charuco_tracker = CharucoTracker(charuco)
-    
-    stream  = RecordedStream(recording_directory,port=1,rotation_count=0, tracker=charuco_tracker)
 
-    camera = CameraData(port=0,size=stream.size)
+    stream = RecordedStream(
+        recording_directory, port=1, rotation_count=0, tracker=charuco_tracker
+    )
 
-    assert(camera.rotation is None)
-    assert(camera.translation is None)
-    assert(camera.matrix is None)
-    assert(camera.distortions is None)
-    
+    camera = CameraData(port=0, size=stream.size)
+
+    assert camera.rotation is None
+    assert camera.translation is None
+    assert camera.matrix is None
+    assert camera.distortions is None
+
     intrinsic_calibrator = IntrinsicCalibrator(camera, stream)
 
     frame_q = Queue()
     stream.subscribe(frame_q)
-    
+
     stream.play_video()
     stream.pause()
 
-    packet = frame_q.get() # pull off frame 0 to clear queue
+    packet = frame_q.get()  # pull off frame 0 to clear queue
 
     # safety check to really clear queue
     while frame_q.qsize() > 0:
-        packet = frame_q.get() 
+        packet = frame_q.get()
 
-    test_frames = [3,5,7,9,20,25]
+    test_frames = [3, 5, 7, 9, 20, 25]
     for i in test_frames:
         stream.jump_to(i)
         packet = frame_q.get()
-        assert(i == packet.frame_index)
+        assert i == packet.frame_index
         logger.info(packet.frame_index)
         intrinsic_calibrator.add_frame_packet(packet)
-        intrinsic_calibrator.add_calibration_frame_indices(packet.frame_index)
+        intrinsic_calibrator.add_calibration_frame_index(packet.frame_index)
 
     stream.stop_event.set()
     stream.unpause()
@@ -72,14 +78,94 @@ def test_intrinsic_calibrator():
     logger.info(camera)
 
     # basic assertions to confirm return values from opencv calibration
-    assert(camera.grid_count==6)
-    assert(isinstance(camera.matrix, np.ndarray))
-    assert(isinstance(camera.distortions, np.ndarray))
-    assert(camera.error > 0)
-    
+    assert camera.grid_count == 6
+    assert isinstance(camera.matrix, np.ndarray)
+    assert isinstance(camera.distortions, np.ndarray)
+    assert camera.error > 0
+
     logger.info(camera.get_display_data())
 
 
-if __name__ == "__main__":
-    test_intrinsic_calibrator()
+def test_autopopulate_data():
+    # use a general video file with a charuco for convenience
+    original_data_path = Path(__root__, "tests", "sessions", "4_cam_recording")
+    destination_path = Path(
+        __root__, "tests", "sessions_copy_delete", "4_cam_recording"
+    )
+    copy_contents(original_data_path, destination_path)
+
+    recording_directory = Path(
+        __root__, "tests", "sessions", "post_monocal", "calibration", "extrinsic"
+    )
+
+    charuco = Charuco(
+        4, 5, 11, 8.5, aruco_scale=0.75, square_size_overide_cm=5.25, inverted=True
+    )
+
+    charuco_tracker = CharucoTracker(charuco)
+
+    stream = RecordedStream(
+        recording_directory, port=1, rotation_count=0, tracker=charuco_tracker
+    )
+
+    camera = CameraData(port=0, size=stream.size)
+
+    assert camera.rotation is None
+    assert camera.translation is None
+    assert camera.matrix is None
+    assert camera.distortions is None
+
+    intrinsic_calibrator = IntrinsicCalibrator(camera, stream)
+
+    # handy way to peek into what is going on
+    frame_q = Queue()
+    stream.subscribe(frame_q)
+    stream.set_fps_target(100)
+    stream.play_video()
+    stream.pause()
+
+    packet = frame_q.get()  # pull off frame 0 to clear queue
+
+    target_grid_count = 25
+    wait_between = 3
+    threshold_corner_count = 6
+    intrinsic_calibrator.initiate_auto_pop(
+        wait_between=wait_between,
+        threshold_corner_count=threshold_corner_count,
+        target_grid_count=target_grid_count,
+    )
+
+    stream.jump_to(0)
+    stream.unpause()
     
+    while intrinsic_calibrator.auto_store_data.is_set():
+        actual_grid_count = len(intrinsic_calibrator.calibration_frame_indices)
+        logger.info(f"waiting for data to populate...currently {actual_grid_count}")
+        
+        sleep(.5)
+
+    # actual_grid_count = len(intrinsic_calibrator.calibration_frame_indices)
+    # # build new frame list
+    # new_potential_frames = []
+    # for frame_index, ids in intrinsic_calibrator.all_ids.items():
+    #     if frame_index not in intrinsic_calibrator.calibration_frame_indices:
+    #         if len(ids) > 3: # just a quick check for minimal data in the frame
+    #             new_potential_frames.append(frame_index)
+            
+    # sample_size = target_grid_count-actual_grid_count
+    # sample_size = min(sample_size, len(new_potential_frames))
+    # sample_size = max(sample_size,0)
+
+    # random_frames = random.sample(new_potential_frames,sample_size)
+    # for frame in random_frames:
+    #     intrinsic_calibrator.add_calibration_frame_index(frame)
+
+    intrinsic_calibrator.backfill_calibration_frames()
+    intrinsic_calibrator.calibrate_camera()
+    assert(camera.grid_count ==target_grid_count)
+    logger.info(f"Calibration complete: {camera}")
+
+if __name__ == "__main__":
+
+    # test_intrinsic_calibrator()
+    test_autopopulate_data()


### PR DESCRIPTION
Provided with a target grid_count, the recorded streams will now play out (with the GUI locked down) while the intrinsic calibrator records all the tracked corners and flags those that will be used for the actual calibration.

Improvements have also been made to the management of QThreads in the controller layer and locking out GUI functionality when mid-process.