### PR TITLE
594 launch video display widget during processing

### DIFF
--- a/dev/demo/demo_synched_frames_widget.py
+++ b/dev/demo/demo_synched_frames_widget.py
@@ -1,7 +1,7 @@
 from PySide6.QtWidgets import QApplication
 import sys
 
-from pyxy3d.gui.synched_frames_widget import SynchedFramesWidget
+from pyxy3d.gui.synched_frames_widget import SynchedFramesDisplay
 from pyxy3d.controller import Controller
 
 from pathlib import Path
@@ -14,16 +14,17 @@ import pyxy3d.logger
 logger = pyxy3d.logger.get(__name__)
 app = QApplication(sys.argv)
 # Define the input file path here.
-original_workspace_dir = Path(__root__, "tests", "sessions", "4_cam_recording")
-workspace_dir = Path(__root__, "tests", "sessions_copy_delete", "4_cam_recording")
+original_workspace_dir = Path(__root__, "tests", "sessions", "mediapipe_calibration")
+workspace_dir = Path(__root__, "tests", "sessions_copy_delete", "4_cam_record")
 
 copy_contents(original_workspace_dir, workspace_dir)
 
 controller = Controller(workspace_dir)
 controller.load_camera_array()
 controller.load_extrinsic_stream_manager()
-controller.process_extrinsic_streams()
-window = SynchedFramesWidget(controller)
+
+controller.extrinsic_stream_manager.process_streams(fps_target=100)
+window = SynchedFramesDisplay(controller.extrinsic_stream_manager)
 window.show()
 window.resize(800, 600)
 logger.info("About to show window")

--- a/dev/demo/demo_synched_frames_widget.py
+++ b/dev/demo/demo_synched_frames_widget.py
@@ -1,7 +1,7 @@
 from PySide6.QtWidgets import QApplication
 import sys
 
-from pyxy3d.gui.synched_frames_widget import SynchedFramesDisplay
+from pyxy3d.gui.synched_frames_display import SynchedFramesDisplay
 from pyxy3d.controller import Controller
 
 from pathlib import Path
@@ -9,7 +9,7 @@ from pathlib import Path
 from pyxy3d import __root__
 from pyxy3d.helper import copy_contents
 import pyxy3d.logger
-
+from time import sleep
 
 logger = pyxy3d.logger.get(__name__)
 app = QApplication(sys.argv)
@@ -25,6 +25,12 @@ controller.load_extrinsic_stream_manager()
 
 controller.extrinsic_stream_manager.process_streams(fps_target=100)
 window = SynchedFramesDisplay(controller.extrinsic_stream_manager)
+# need to let synchronizer spin up before able to display frames
+# need to let synchronizer spin up before able to display frames
+
+while not hasattr(controller.extrinsic_stream_manager.synchronizer, "current_sync_packet"):
+    sleep(0.25)
+
 window.show()
 window.resize(800, 600)
 logger.info("About to show window")

--- a/pyxy3d/calibration/intrinsic_calibrator.py
+++ b/pyxy3d/calibration/intrinsic_calibrator.py
@@ -114,7 +114,7 @@ class IntrinsicCalibrator:
                     # count down to the next frame to consider autopopulating
                     self.auto_pop_frame_wait = max(self.auto_pop_frame_wait-1,0)       
                 
-                logger.info(f"Current index is {index}")
+                logger.debug(f"Current index is {index}")
                 if index == self.stream.last_frame_index:
                 # end of stream, so stop auto pop and backfill to hit grid target
                     logger.info("End of autopop detected...")

--- a/pyxy3d/controller.py
+++ b/pyxy3d/controller.py
@@ -156,24 +156,24 @@ class Controller(QObject):
             tracker=self.charuco_tracker,
         )
 
-    def process_extrinsic_streams(self, fps_target=None):
-        def worker():
-            output_path = Path(
-                self.workspace_guide.extrinsic_dir, "CHARUCO", "xy_CHARUCO.csv"
-            )
-            output_path.unlink()  # make sure this doesn't exist to begin with.
+    # def process_extrinsic_streams(self, fps_target=None):
+    #     def worker():
+    #         output_path = Path(
+    #             self.workspace_guide.extrinsic_dir, "CHARUCO", "xy_CHARUCO.csv"
+    #         )
+    #         output_path.unlink()  # make sure this doesn't exist to begin with.
 
-            self.load_extrinsic_stream_manager()
-            self.extrinsic_stream_manager.process_streams(fps_target=fps_target)
+    #         self.load_extrinsic_stream_manager()
+    #         self.extrinsic_stream_manager.process_streams(fps_target=fps_target)
 
-            logger.info(
-                f"Processing of extrinsic calibration begun...waiting for output to populate: {output_path}"
-            )
-            while not output_path.exists():
-                sleep(0.5)
-                logger.info(
-                    f"Waiting for 2D tracked points to populate at {output_path}"
-                )
+    #         logger.info(
+    #             f"Processing of extrinsic calibration begun...waiting for output to populate: {output_path}"
+    #         )
+    #         while not output_path.exists():
+    #             sleep(0.5)
+    #             logger.info(
+    #                 f"Waiting for 2D tracked points to populate at {output_path}"
+    #             )
 
     def load_intrinsic_stream_manager(self):
         self.intrinsic_stream_manager = IntrinsicStreamManager(
@@ -353,7 +353,7 @@ class Controller(QObject):
                     )
 
             # note that this processing will wait until it is complete
-            self.process_extrinsic_streams(fps_target=100)
+            # self.process_extrinsic_streams(fps_target=100)
             logger.info("Processing if extrinsic caliberation streams complete...")
 
             self.extrinsic_calibration_xy = Path(

--- a/pyxy3d/controller.py
+++ b/pyxy3d/controller.py
@@ -55,7 +55,8 @@ class Controller(QObject):
     capture_volume_shifted = Signal()
     enable_inputs = Signal(int, bool)  # port, enable
     post_processing_complete = Signal()
-
+    show_synched_frames = Signal()
+    
     def __init__(self, workspace_dir: Path):
         super().__init__()
         self.workspace = workspace_dir
@@ -339,11 +340,13 @@ class Controller(QObject):
 
             self.load_extrinsic_stream_manager()
             self.extrinsic_stream_manager.process_streams(fps_target=100)
-
             logger.info(
                 f"Processing of extrinsic calibration begun...waiting for output to populate: {output_path}"
             )
 
+            logger.info("About to signal that synched frames should be shown")
+            self.show_synched_frames.emit()
+            
             while not output_path.exists():
                 sleep(0.5)
                 # moderate the frequency with which logging statements get made

--- a/pyxy3d/gui/frame_emitters/tools.py
+++ b/pyxy3d/gui/frame_emitters/tools.py
@@ -1,4 +1,5 @@
 import cv2
+import numpy as np
 from PySide6.QtGui import QImage
 import pyxy3d.logger
 

--- a/pyxy3d/gui/frame_emitters/tools.py
+++ b/pyxy3d/gui/frame_emitters/tools.py
@@ -13,7 +13,7 @@ def resize_to_square(frame):
     height_pad = int((padded_size - height) / 2)
     width_pad = int((padded_size - width) / 2)
     pad_color = [0, 0, 0]
-    pad_color = [100, 100, 100]
+    # pad_color = [100, 100, 100]
 
     frame = cv2.copyMakeBorder(
         frame,

--- a/pyxy3d/gui/synched_frames_widget.py
+++ b/pyxy3d/gui/synched_frames_widget.py
@@ -6,6 +6,7 @@ from PySide6.QtCore import Slot
 from PySide6.QtGui import QPixmap
 from PySide6.QtWidgets import (
     QGridLayout,
+    QMainWindow,
     QWidget,
     QLineEdit,
     QHBoxLayout,
@@ -15,18 +16,25 @@ from PySide6.QtWidgets import (
 
 from pyxy3d.cameras.synchronizer import Synchronizer
 from pyxy3d.gui.frame_emitters.frame_dictionary_emitter import FrameDictionaryEmitter
+from pyxy3d.synchronized_stream_manager import SynchronizedStreamManager
 from pyxy3d.controller import Controller
 
 logger = pyxy3d.logger.get(__name__)
 
 
-class SynchedFramesWidget(QWidget):
-    def __init__(self, controller: Controller):
-        super(SynchedFramesWidget, self).__init__()
-        self.controller = controller
-        self.synchronizer: Synchronizer = (
-            self.controller.extrinsic_stream_manager.synchronizer
-        )
+class SynchedFramesDisplay(QWidget):
+    """
+    This widget is not intended to have any interactive functionality at all and to only 
+    provide a window to the user of the current landmark tracking
+    
+    This is why the primary input is the sync stream manager directly and not the controller 
+    Apologies to Future Mac who is reading this and regretting my decisions.
+    """
+
+    def __init__(self, sync_stream_manager: SynchronizedStreamManager):
+        super(SynchedFramesDisplay, self).__init__()
+        self.sync_stream_manager = sync_stream_manager 
+        self.synchronizer = self.sync_stream_manager.synchronizer
         self.ports = self.synchronizer.ports
 
         # need to let synchronizer spin up before able to display frames
@@ -35,7 +43,7 @@ class SynchedFramesWidget(QWidget):
 
         # create tools to build and emit the displayed frame
         self.frame_dictionary_emitter = FrameDictionaryEmitter(
-            self.synchronizer, self.controller.camera_array.cameras
+            self.synchronizer, self.sync_stream_manager.all_camera_data
         )
         self.frame_dictionary_emitter.start()
 

--- a/pyxy3d/gui/workspace_widget.py
+++ b/pyxy3d/gui/workspace_widget.py
@@ -1,6 +1,9 @@
 import os
+from pyxy3d.gui.synched_frames_display import SynchedFramesDisplay
+from PySide6.QtCore import QThread
 import sys
 import subprocess
+import time
 from pathlib import Path
 from PySide6.QtWidgets import QHBoxLayout, QLabel, QWidget, QVBoxLayout, QPushButton, QSpinBox, QGridLayout, QTextBrowser
 from PySide6.QtCore import QFileSystemWatcher, Slot, Qt
@@ -50,7 +53,8 @@ class WorkspaceSummaryWidget(QWidget):
         self.open_workspace_folder_btn.clicked.connect(self.open_workspace)  
         self.calibrate_btn.clicked.connect(self.on_calibrate_btn_clicked)
         self.camera_count_spin.valueChanged.connect(self.set_camera_count)
-        
+        self.controller.show_synched_frames.connect(self.show_synched_frames)
+
     def on_calibrate_btn_clicked(self):
         logger.info("Calling controller to process extrinsic streams into 2D data")
         # Call the extrinsic calibration method in the controller
@@ -68,6 +72,10 @@ class WorkspaceSummaryWidget(QWidget):
         else:  # Linux and Unix-like systems
             subprocess.run(["xdg-open", self.controller.workspace])
 
-            
+    def show_synched_frames(self):
+        logger.info("About to launch synced Frames Display")
+        self.display_window = SynchedFramesDisplay(self.controller.extrinsic_stream_manager)
+        self.display_window.show()
+                
     def update_status(self):
         self.status_HTML.setHtml(self.controller.workspace_guide.get_html_summary())

--- a/pyxy3d/recording/recorded_stream.py
+++ b/pyxy3d/recording/recorded_stream.py
@@ -236,7 +236,7 @@ class RecordedStream(Stream):
             # self.out_q.put(frame_packet)
             self.frame_index += 1
 
-            if self.frame_index >= self.last_frame_index and self.break_on_last:
+            if self.frame_index > self.last_frame_index and self.break_on_last:
                 logger.info(f"Ending recorded playback at port {self.port}")
                 # time of -1 indicates end of stream
                 frame_packet = FramePacket(

--- a/tests/test_intrinsic_calibrator.py
+++ b/tests/test_intrinsic_calibrator.py
@@ -167,5 +167,5 @@ def test_autopopulate_data():
 
 if __name__ == "__main__":
 
-    # test_intrinsic_calibrator()
+    test_intrinsic_calibrator()
     test_autopopulate_data()


### PR DESCRIPTION
Synchronized frame widget now shows the active landmark tracking that occurs during the extrinsic calibration.

This should carry over in a fairly direct manner to the the landmark tracking that occurs during motion capture....